### PR TITLE
Fix CI workflow ruff step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
+          pip install ruff==0.12.1 black==25.1.0 pytest
       - name: Ruff lint
-        run: ruff --format=github .
+        run: ruff check --output-format=github .
       - name: Black check
         run: black --check .
       - name: Run tests


### PR DESCRIPTION
## Summary
- ensure linting tools are installed in CI
- fix ruff command in CI

## Testing
- `ruff check --output-format=github .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862ef731178832d9cccdd238ae49ffa