### PR TITLE
Implement Redis-based notifications

### DIFF
--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -64,7 +64,11 @@ async def limits_check(
         lines = ["Превышение лимитов:"] + [
             f"{r.category}: {r.spent} из {r.limit}" for r in result
         ]
-        background_tasks.add_task(notifications.send_message, "\n".join(lines))
+        background_tasks.add_task(
+            notifications.send_message,
+            "\n".join(lines),
+            current_user.account_id,
+        )
     return result
 
 

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 import asyncio
 
-from .celery_app import celery_app
-from . import notifications, banks, crud, database, schemas
+from ..celery_app import celery_app
+from .. import notifications, banks, crud, database, schemas
 
 
 @celery_app.task
@@ -52,11 +52,7 @@ def check_limits_task(account_id: int, year: int, month: int) -> int:
             f"{r[0]}: {float(r[2])} из {float(r[1])}" for r in rows
         ]
         message = "\n".join(lines)
-        await notifications.send_message(message)
-        async with database.async_session() as session:
-            subs = await crud.get_push_subscriptions(session, account_id)
-        for s in subs:
-            notifications.send_push(s.endpoint, s.p256dh, s.auth, message)
+        await notifications.send_message(message, account_id)
         return len(rows)
 
     return asyncio.run(_run())
@@ -84,3 +80,4 @@ def process_recurring_task(date: str) -> int:
             return created
 
     return asyncio.run(_run())
+

--- a/app/tasks/notify_worker.py
+++ b/app/tasks/notify_worker.py
@@ -1,0 +1,31 @@
+import asyncio
+import os
+import redis.asyncio as redis
+
+from .. import notifications, crud, database
+
+REDIS_URL = os.getenv("REDIS_URL", os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0"))
+
+
+async def main() -> None:
+    r = redis.from_url(REDIS_URL, decode_responses=True)
+    last_id = "0-0"
+    while True:
+        streams = await r.xread({"notifications": last_id}, block=0, count=1)
+        if not streams:
+            continue
+        _, messages = streams[0]
+        for msg_id, data in messages:
+            last_id = msg_id
+            text = data.get("text", "")
+            account_id = data.get("account_id")
+            await notifications.send_telegram(text)
+            if account_id:
+                async with database.async_session() as session:
+                    subs = await crud.get_push_subscriptions(session, int(account_id))
+                for s in subs:
+                    notifications.send_push(s.endpoint, s.p256dh, s.auth, text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,5 +36,17 @@ services:
     depends_on:
       - db
       - redis
+  notify_worker:
+    build: .
+    command: python -m app.tasks.notify_worker
+    volumes:
+      - .:/app
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/budget
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
+    depends_on:
+      - db
+      - redis
 volumes:
   db_data:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import time
+import subprocess
+from pathlib import Path
+import redis
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+DB_PATH = Path("test.db")
+if DB_PATH.exists():
+    DB_PATH.unlink()
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test.db"
+
+from app.main import app  # noqa: E402
+
+
+def _login(client):
+    user = {"email": "notif@example.com", "password": "pass"}
+    r = client.post("/пользователи/", json=user)
+    assert r.status_code == 200
+    r = client.post(
+        "/пользователи/token",
+        data={"username": user["email"], "password": user["password"]},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def test_notification_stream():
+    proc = subprocess.Popen([
+        "redis-server",
+        "--port",
+        "6379",
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    rds = redis.Redis.from_url("redis://localhost:6379/0", decode_responses=True)
+    # wait for server to be ready
+    for _ in range(10):
+        try:
+            rds.ping()
+            break
+        except redis.exceptions.ConnectionError:
+            time.sleep(0.1)
+    rds.flushall()
+    try:
+        with TestClient(app) as client:
+            token = _login(client)
+            headers = {"Authorization": f"Bearer {token}"}
+
+            r = client.post(
+                "/категории/",
+                json={"name": "Нотиф", "monthly_limit": 100},
+                headers=headers,
+            )
+            cat_id = r.json()["id"]
+
+            tx = {
+                "amount": 150,
+                "currency": "RUB",
+                "description": "Магазин",
+                "category_id": cat_id,
+                "created_at": "2025-06-15T12:00:00",
+            }
+            client.post("/операции/", json=tx, headers=headers)
+
+            r = client.get(
+                "/аналитика/лимиты?year=2025&month=6&notify=true",
+                headers=headers,
+            )
+            assert r.status_code == 200
+            time.sleep(0.5)
+            rds = redis.Redis.from_url("redis://localhost:6379/0", decode_responses=True)
+            messages = rds.xrange("notifications")
+            assert len(messages) == 1
+            assert "Превышение лимитов" in messages[0][1]["text"]
+    finally:
+        proc.terminate()
+        proc.wait()


### PR DESCRIPTION
## Summary
- refactor Celery tasks into a package
- queue notifications to Redis stream
- add worker for telegram/web push from stream
- support notification account IDs
- run new worker in docker compose
- test that API pushes notification to Redis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f332eaac832d9c43044efc686db2