### PR TITLE
Fix black formatting

### DIFF
--- a/app/notifications.py
+++ b/app/notifications.py
@@ -8,11 +8,14 @@ from pywebpush import webpush
 
 TOKEN = os.getenv("TELEGRAM_TOKEN")
 CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
-REDIS_URL = os.getenv("REDIS_URL", os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0"))
+REDIS_URL = os.getenv(
+    "REDIS_URL", os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+)
 VAPID_PRIVATE_KEY = os.getenv("VAPID_PRIVATE_KEY")
 VAPID_CLAIMS = {"sub": os.getenv("VAPID_SUB", "mailto:admin@example.com")}
 
 redis_client = redis.from_url(REDIS_URL, decode_responses=True)
+
 
 async def send_message(text: str, account_id: int | None = None) -> None:
     """Добавить сообщение в стрим Redis."""

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -80,4 +80,3 @@ def process_recurring_task(date: str) -> int:
             return created
 
     return asyncio.run(_run())
-

--- a/app/tasks/notify_worker.py
+++ b/app/tasks/notify_worker.py
@@ -4,7 +4,9 @@ import redis.asyncio as redis
 
 from .. import notifications, crud, database
 
-REDIS_URL = os.getenv("REDIS_URL", os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0"))
+REDIS_URL = os.getenv(
+    "REDIS_URL", os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+)
 
 
 async def main() -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -30,11 +30,15 @@ def _login(client):
 
 
 def test_notification_stream():
-    proc = subprocess.Popen([
-        "redis-server",
-        "--port",
-        "6379",
-    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    proc = subprocess.Popen(
+        [
+            "redis-server",
+            "--port",
+            "6379",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
     rds = redis.Redis.from_url("redis://localhost:6379/0", decode_responses=True)
     # wait for server to be ready
     for _ in range(10):
@@ -71,7 +75,9 @@ def test_notification_stream():
             )
             assert r.status_code == 200
             time.sleep(0.5)
-            rds = redis.Redis.from_url("redis://localhost:6379/0", decode_responses=True)
+            rds = redis.Redis.from_url(
+                "redis://localhost:6379/0", decode_responses=True
+            )
             messages = rds.xrange("notifications")
             assert len(messages) == 1
             assert "Превышение лимитов" in messages[0][1]["text"]


### PR DESCRIPTION
## Summary
- fix formatting flagged by Black for telegram notifications and tasks

## Testing
- `pre-commit run --files app/notifications.py app/tasks/notify_worker.py app/tasks/__init__.py tests/test_notifications.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862f7381d68832db702b9d479ffd4e2