### PR TITLE
Add TimescaleDB and ClickHouse

### DIFF
--- a/alembic/versions/0d74380f2dbb_timescaledb_migration.py
+++ b/alembic/versions/0d74380f2dbb_timescaledb_migration.py
@@ -1,0 +1,26 @@
+"""migrate to timescaledb
+
+Revision ID: 0d74380f2dbb
+Revises: ef92c9828b2b
+Create Date: 2025-07-01 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0d74380f2dbb"
+down_revision: Union[str, Sequence[str], None] = "ef92c9828b2b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS timescaledb")
+    op.execute(
+        "SELECT create_hypertable('transactions', 'created_at', if_not_exists => TRUE)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP EXTENSION IF EXISTS timescaledb")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   db:
-    image: postgres:15
+    image: timescale/timescaledb:2.13.0-pg15
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -51,6 +51,7 @@ services:
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       KAFKA_BROKER_URL: kafka:9092
+      CLICKHOUSE_HOST: clickhouse
     ports:
       - "8000:8000"
     depends_on:
@@ -66,6 +67,7 @@ services:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/budget
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
+      CLICKHOUSE_HOST: clickhouse
     depends_on:
       - db
       - redis
@@ -79,6 +81,7 @@ services:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/budget
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
+      CLICKHOUSE_HOST: clickhouse
     depends_on:
       - db
       - redis
@@ -92,8 +95,18 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/budget
       KAFKA_BROKER_URL: kafka:9092
+      CLICKHOUSE_HOST: clickhouse
     depends_on:
       - db
       - kafka
+  clickhouse:
+    image: clickhouse/clickhouse-server:23.3
+    ports:
+      - "8123:8123"
+    environment:
+      CLICKHOUSE_DB: budget
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
 volumes:
   db_data:
+  clickhouse_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ python-telegram-bot==20.3
 pywebpush
 prometheus-fastapi-instrumentator
 aiokafka
+clickhouse-connect


### PR DESCRIPTION
## Summary
- switch postgres to `timescaledb` image
- export monthly summaries to ClickHouse via Celery task
- add ClickHouse container to compose file
- include TimescaleDB migration for transactions
- add clickhouse-connect dependency

## Testing
- `pre-commit run --files docker-compose.yml alembic/versions/0d74380f2dbb_timescaledb_migration.py app/tasks/__init__.py requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fcfca1ac832db164fd7e60a60780