### PR TITLE
Integrate Vault for storing bank tokens

### DIFF
--- a/app/banks/__init__.py
+++ b/app/banks/__init__.py
@@ -6,13 +6,13 @@ from .sber import SberConnector
 from .gazprom import GazpromConnector
 
 
-def get_connector(name: str, token: str) -> BankConnector:
+def get_connector(name: str, user_id: int, token: str | None = None) -> BankConnector:
     """Получить коннектор по названию банка."""
     name = name.lower()
     if name in ("tinkoff", "тинькофф"):
-        return TinkoffConnector(token)
+        return TinkoffConnector(user_id, token)
     if name in ("sber", "sberbank", "сбер", "сбербанк"):
-        return SberConnector(token)
+        return SberConnector(user_id, token)
     if name in ("gazprom", "gazprombank", "газпром", "газпромбанк"):
-        return GazpromConnector(token)
+        return GazpromConnector(user_id, token)
     raise ValueError("Неизвестный банк")

--- a/app/banks/base.py
+++ b/app/banks/base.py
@@ -1,14 +1,23 @@
 from datetime import datetime
 from typing import List
 
-from .. import schemas
+from .. import schemas, vault
 
 
 class BankConnector:
     """Базовый интерфейс коннектора банка."""
 
-    def __init__(self, token: str) -> None:
+    token_key: str = ""
+
+    def __init__(self, user_id: int, token: str | None = None) -> None:
+        self.user_id = user_id
         self.token = token
+        self.vault = vault.get_vault_client()
+
+    async def _get_token(self) -> str | None:
+        if self.token is None and self.token_key:
+            self.token = await self.vault.read(f"{self.token_key}/{self.user_id}")
+        return self.token
 
     async def fetch_transactions(
         self, start: datetime, end: datetime

--- a/app/banks/gazprom.py
+++ b/app/banks/gazprom.py
@@ -8,6 +8,8 @@ from .base import BankConnector
 class GazpromConnector(BankConnector):
     """Заглушка коннектора Газпромбанка."""
 
+    token_key = "gazprom_token"
+
     async def fetch_transactions(
         self, start: datetime, end: datetime
     ) -> List[schemas.TransactionCreate]:

--- a/app/banks/sber.py
+++ b/app/banks/sber.py
@@ -8,6 +8,8 @@ from .base import BankConnector
 class SberConnector(BankConnector):
     """Заглушка коннектора Сбербанка."""
 
+    token_key = "sber_token"
+
     async def fetch_transactions(
         self, start: datetime, end: datetime
     ) -> List[schemas.TransactionCreate]:

--- a/app/banks/tinkoff.py
+++ b/app/banks/tinkoff.py
@@ -13,9 +13,7 @@ class TinkoffConnector(BankConnector):
     """Простейший коннектор к API Тинькофф."""
 
     BASE_URL = "https://api.tinkoff.ru/v1/"
-
-    def __init__(self, token: str):
-        self.token = token
+    token_key = "tinkoff_token"
 
     async def fetch_transactions(
         self, start: datetime, end: datetime
@@ -25,7 +23,10 @@ class TinkoffConnector(BankConnector):
         В реальном приложении здесь будет вызов API банка. Этот код лишь
         демонстрирует общую структуру и не обращается к закрытым эндпоинтам.
         """
-        headers = {"Authorization": f"Bearer {self.token}"}
+        token = await self._get_token()
+        if not token:
+            return []
+        headers = {"Authorization": f"Bearer {token}"}
         params = {
             "from": int(start.timestamp() * 1000),
             "to": int(end.timestamp() * 1000),

--- a/app/routers/jobs.py
+++ b/app/routers/jobs.py
@@ -20,10 +20,9 @@ async def import_transactions_job(
 ):
     """Запустить импорт операций в фоне."""
     if token is None:
-        token_obj = await crud.get_bank_token(session, bank, current_user.account_id)
+        token_obj = await crud.get_bank_token(session, bank, current_user.id)
         if not token_obj:
             raise HTTPException(status_code=404, detail="Токен не найден")
-        token = token_obj.token
     result = tasks.import_transactions_task.delay(
         bank,
         token,

--- a/app/routers/tokens.py
+++ b/app/routers/tokens.py
@@ -13,7 +13,7 @@ async def read_tokens(
     session: AsyncSession = Depends(database.get_session),
 ):
     """Список сохранённых токенов банков."""
-    return await crud.get_bank_tokens(session, current_user.account_id)
+    return await crud.get_bank_tokens(session, current_user.id)
 
 
 @router.post("/", response_model=schemas.BankToken)
@@ -23,9 +23,7 @@ async def set_token(
     session: AsyncSession = Depends(database.get_session),
 ):
     """Сохранить или обновить токен банка."""
-    return await crud.set_bank_token(
-        session, data.bank, data.token, current_user.account_id, current_user.id
-    )
+    return await crud.set_bank_token(session, data.bank, data.token, current_user.id)
 
 
 @router.delete("/{bank}", status_code=204)
@@ -35,5 +33,5 @@ async def delete_token(
     session: AsyncSession = Depends(database.get_session),
 ):
     """Удалить токен банка."""
-    await crud.delete_bank_token(session, bank, current_user.account_id)
+    await crud.delete_bank_token(session, bank, current_user.id)
     return None

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -16,7 +16,7 @@ def send_telegram(text: str) -> None:
 @celery_app.task
 def import_transactions_task(
     bank: str,
-    token: str,
+    token: str | None,
     start: str,
     end: str,
     account_id: int,
@@ -25,7 +25,7 @@ def import_transactions_task(
     """Импортировать операции из банка."""
 
     async def _run() -> int:
-        connector = banks.get_connector(bank, token)
+        connector = banks.get_connector(bank, user_id, token)
         txs = await connector.fetch_transactions(
             datetime.fromisoformat(start),
             datetime.fromisoformat(end),

--- a/app/vault.py
+++ b/app/vault.py
@@ -1,0 +1,45 @@
+import os
+from functools import lru_cache
+
+import httpx
+
+
+class VaultClient:
+    """Minimal async Vault client for KV engine."""
+
+    def __init__(self, url: str | None = None, token: str | None = None) -> None:
+        self.url = url or os.getenv("VAULT_ADDR", "http://localhost:8200")
+        self.token = token or os.getenv("VAULT_TOKEN", "root")
+        self.headers = {"X-Vault-Token": self.token}
+
+    async def read(self, path: str) -> str | None:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self.url}/v1/secret/{path}", headers=self.headers, timeout=5
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                return data.get("data", {}).get("value")
+            return None
+
+    async def write(self, path: str, value: str) -> None:
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                f"{self.url}/v1/secret/{path}",
+                headers=self.headers,
+                json={"value": value},
+                timeout=5,
+            )
+
+    async def delete(self, path: str) -> None:
+        async with httpx.AsyncClient() as client:
+            await client.delete(
+                f"{self.url}/v1/secret/{path}",
+                headers=self.headers,
+                timeout=5,
+            )
+
+
+@lru_cache
+def get_vault_client() -> VaultClient:
+    return VaultClient()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,13 @@ services:
       - db_data:/var/lib/postgresql/data
   redis:
     image: redis:7
+  vault:
+    image: hashicorp/vault:1.13
+    ports:
+      - "8200:8200"
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: root
+      VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
     environment:
@@ -52,12 +59,14 @@ services:
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       KAFKA_BROKER_URL: kafka:9092
       CLICKHOUSE_HOST: clickhouse
+      VAULT_ADDR: http://vault:8200
     ports:
       - "8000:8000"
     depends_on:
       - db
       - redis
       - kafka
+      - vault
   worker:
     build: .
     command: celery -A app.tasks worker --loglevel=info
@@ -68,10 +77,12 @@ services:
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       CLICKHOUSE_HOST: clickhouse
+      VAULT_ADDR: http://vault:8200
     depends_on:
       - db
       - redis
       - kafka
+      - vault
   notify_worker:
     build: .
     command: python -m app.tasks.notify_worker
@@ -82,10 +93,12 @@ services:
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       CLICKHOUSE_HOST: clickhouse
+      VAULT_ADDR: http://vault:8200
     depends_on:
       - db
       - redis
       - kafka
+      - vault
 
   bank_import:
     build: .
@@ -96,6 +109,7 @@ services:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/budget
       KAFKA_BROKER_URL: kafka:9092
       CLICKHOUSE_HOST: clickhouse
+      VAULT_ADDR: http://vault:8200
     depends_on:
       - db
       - kafka

--- a/services/bank_import/main.py
+++ b/services/bank_import/main.py
@@ -22,7 +22,7 @@ consumer: AIOKafkaConsumer | None = None
 
 
 async def process_message(data: dict) -> None:
-    connector = banks.get_connector(data["bank"], data["token"])
+    connector = banks.get_connector(data["bank"], data["user_id"], data.get("token"))
     txs = await connector.fetch_transactions(
         datetime.fromisoformat(data["start"]),
         datetime.fromisoformat(data["end"]),


### PR DESCRIPTION
## Summary
- add Vault service and address for other services in `docker-compose.yml`
- introduce `app/vault.py` with a tiny async client
- fetch bank tokens from Vault inside connectors
- switch CRUD functions and routers to use Vault
- adjust Celery task and import service for new API
- update tests with Vault stubs
- fix forecast calculation when month has ended

## Testing
- `pre-commit run --files app/crud.py tests/test_banks.py tests/test_tokens.py app/routers/tokens.py app/routers/banks.py app/routers/jobs.py app/banks/base.py app/banks/tinkoff.py app/banks/sber.py app/banks/gazprom.py app/banks/__init__.py services/bank_import/main.py app/vault.py docker-compose.yml requirements.txt app/tasks/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e06e5c74832d94934c88514397e9