### PR TITLE
Add deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,3 +227,7 @@ npm run build
 `grafana_dashboard.json`.
 Создайте источник данных Prometheus в Grafana и импортируйте этот файл,
 чтобы наблюдать статистику запросов.
+
+## Deployment
+
+Инструкции по развёртыванию инфраструктуры Terraform и деплою Helm/Argo CD описаны в [docs/deployment.md](docs/deployment.md).

--- a/deploy/argocd/applicationset.yaml
+++ b/deploy/argocd/applicationset.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: budget-machine-prs
+spec:
+  generators:
+    - pullRequest:
+        github:
+          owner: example
+          repo: budget-machine
+          tokenRef:
+            secretName: github-token
+            key: token
+        requeueAfterSeconds: 180
+        filters:
+          - branchMatch: ".*"
+  template:
+    metadata:
+      name: 'budget-machine-pr-{{number}}'
+    spec:
+      project: default
+      source:
+        repoURL: 'https://github.com/example/budget-machine'
+        targetRevision: '{{branch}}'
+        path: deploy/helm
+        helm:
+          valueFiles:
+            - values.yaml
+      destination:
+        server: 'https://kubernetes.default.svc'
+        namespace: 'pr-{{number}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true

--- a/deploy/argocd/rollout-example.yaml
+++ b/deploy/argocd/rollout-example.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: budget-machine-rollout
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/budget-machine
+    targetRevision: HEAD
+    path: deploy/helm
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: budget-machine
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: budget-machine
+version: 0.1.0
+description: Helm chart for the budget-machine application
+type: application
+appVersion: "0.1.0"

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "budget-machine.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "budget-machine.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "budget-machine.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "budget-machine.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "budget-machine.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "budget-machine.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ include "budget-machine.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DATABASE_URL
+              value: {{ .Values.env.DATABASE_URL | quote }}
+            - name: SECRET_KEY
+              value: {{ .Values.env.SECRET_KEY | quote }}
+          ports:
+            - containerPort: 8000

--- a/deploy/helm/templates/rollout.yaml
+++ b/deploy/helm/templates/rollout.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ include "budget-machine.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "budget-machine.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "budget-machine.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "budget-machine.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ include "budget-machine.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DATABASE_URL
+              value: {{ .Values.env.DATABASE_URL | quote }}
+            - name: SECRET_KEY
+              value: {{ .Values.env.SECRET_KEY | quote }}
+          ports:
+            - containerPort: 8000
+  strategy:
+    canary:
+      steps:
+        - setWeight: 50
+        - pause: { duration: 30 }
+        - setWeight: 100

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "budget-machine.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "budget-machine.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "budget-machine.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,14 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/example/budget-machine
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+env:
+  DATABASE_URL: ""
+  SECRET_KEY: ""

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_providers {
+    yandex = {
+      source  = "yandex-cloud/yandex"
+      version = ">= 0.91"
+    }
+  }
+  required_version = ">= 1.6"
+}
+
+provider "yandex" {
+  token     = var.yc_token
+  cloud_id  = var.yc_cloud_id
+  folder_id = var.yc_folder_id
+  zone      = var.yc_zone
+}
+
+resource "yandex_kubernetes_cluster" "k8s" {
+  name      = "budget-machine"
+  network_id = var.yc_network_id
+
+  master {
+    version   = "1.27"
+    public_ip = true
+  }
+}
+
+resource "yandex_kubernetes_node_group" "default" {
+  cluster_id = yandex_kubernetes_cluster.k8s.id
+  version    = "1.27"
+  name       = "default"
+
+  scale_policy {
+    fixed_scale {
+      size = 2
+    }
+  }
+
+  instance_template {
+    platform_id = "standard-v3"
+    resources {
+      cores  = 2
+      memory = 4
+    }
+    boot_disk {
+      type = "network-hdd"
+      size = 64
+    }
+  }
+}

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_id" {
+  value = yandex_kubernetes_cluster.k8s.id
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,0 +1,25 @@
+variable "yc_token" {
+  description = "Yandex Cloud OAuth token"
+  type        = string
+}
+
+variable "yc_cloud_id" {
+  description = "Yandex Cloud ID"
+  type        = string
+}
+
+variable "yc_folder_id" {
+  description = "Yandex Cloud folder ID"
+  type        = string
+}
+
+variable "yc_zone" {
+  description = "Zone where resources will be created"
+  type        = string
+  default     = "ru-central1-a"
+}
+
+variable "yc_network_id" {
+  description = "ID of the network used for the cluster"
+  type        = string
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,42 @@
+# Deployment Guide
+
+This document describes how to provision infrastructure and deploy the application using Terraform, Helm and Argo CD.
+
+## Infrastructure with Terraform
+
+The `deploy/terraform` directory contains an example configuration for Yandex Cloud. It provisions a managed Kubernetes cluster and a node group.
+
+```bash
+cd deploy/terraform
+terraform init
+terraform apply
+```
+
+Set the variables `yc_token`, `yc_cloud_id`, `yc_folder_id`, `yc_network_id` and optionally `yc_zone` to match your account.
+
+## Application deployment with Helm
+
+A Helm chart lives in `deploy/helm`. After obtaining kubeconfig for the cluster, install the chart:
+
+```bash
+helm install budget-machine ./deploy/helm \
+  --set env.DATABASE_URL=postgresql://user:pass@db:5432/budget \
+  --set env.SECRET_KEY=change_me
+```
+
+It will create a Deployment, Service and a Rollout resource for canary releases.
+
+## Argo CD
+
+The directory `deploy/argocd` provides manifests for Argo CD.
+
+- `applicationset.yaml` creates preview environments for pull requests using `ApplicationSet`.
+- `rollout-example.yaml` demonstrates how to sync the chart with automated canary rollouts.
+
+Apply them to a running Argo CD instance:
+
+```bash
+kubectl apply -f deploy/argocd/
+```
+
+After that new pull requests will trigger temporary environments and production updates will use Argo Rollouts for gradual rollout.


### PR DESCRIPTION
## Summary
- add Kubernetes Helm chart with Argo Rollout example
- provide Terraform Yandex Cloud infrastructure example
- document Argo CD preview environments and rollout usage
- link new deployment docs from README

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f6c94fd8832d8fa9f8d90b06b9c6