### PR TITLE
Fix dependencies for Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn[standard]
-SQLAlchemy>=1.4
+SQLAlchemy>=2.0
+email-validator>=2.0
 asyncpg
 pydantic
 alembic
@@ -22,4 +23,4 @@ pandas
 catboost
 prophet
 mlflow
-apache-airflow
+apache-airflow==2.8.1


### PR DESCRIPTION
## Summary
- upgrade SQLAlchemy to version compatible with `async_sessionmaker`
- add `email-validator` to meet FastAPI's requirement
- pin Airflow version to avoid install errors on newer pip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686405f1c2fc832d832e6d6188ad0fd5