### PR TITLE
Fix Airflow install on Python 3.12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - db
       - kafka
   airflow:
-    image: apache/airflow:2.8.1
+    image: apache/airflow:2.9.3
     depends_on:
       - kafka
       - clickhouse

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ pandas
 catboost
 prophet
 mlflow
-apache-airflow==2.8.1
+apache-airflow==2.9.3


### PR DESCRIPTION
## Summary
- update Airflow version in requirements
- update Airflow Docker image in compose file

## Testing
- `pre-commit run --files requirements.txt docker-compose.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686408269578832dbf1a0a9352de0a8e