### PR TITLE
Add infrastructure ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,16 @@ frontend/node_modules/
 frontend/dist/
 test.db
 web/node_modules/
+
+# Infrastructure
+# Docker artifacts
+*.tar
+*.img
+/docker-compose.override.yml
+
+# Terraform state
+.terraform/
+*.tfstate*
+
+# Node dependencies
+node_modules/


### PR DESCRIPTION
## Summary
- extend `.gitignore` for Docker and Terraform artifacts
- ensure generic `node_modules/` ignore rule

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi and telegram)*

------
https://chatgpt.com/codex/tasks/task_e_686436a24ee4832da4b6dedc87c30652