### PR TITLE
Simplify docker-compose

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,165 +1,56 @@
 version: '3.9'
 services:
   db:
-    image: timescale/timescaledb:2.13.0-pg15
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: budget
+    image: postgres:16
+    env_file: .env
     volumes:
       - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   redis:
-    image: redis:7
-  vault:
-    image: hashicorp/vault:1.13
-    ports:
-      - "8200:8200"
-    environment:
-      VAULT_DEV_ROOT_TOKEN_ID: root
-      VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+    image: redis:7-alpine
+    env_file: .env
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.5.0
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
+    image: bitnami/zookeeper:3.8
+    env_file: .env
+    healthcheck:
+      test: ["CMD-SHELL", "echo ruok | nc localhost $$ZOOKEEPER_CLIENT_PORT | grep imok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   kafka:
-    image: confluentinc/cp-kafka:7.5.0
+    image: bitnami/kafka:3
     depends_on:
       - zookeeper
-    ports:
-      - "9092:9092"
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-  kafka-connect:
-    image: debezium/connect:2.5
-    depends_on:
-      - kafka
-    ports:
-      - "8083:8083"
-    environment:
-      BOOTSTRAP_SERVERS: kafka:9092
-      GROUP_ID: 1
-      CONFIG_STORAGE_TOPIC: debezium_config
-      OFFSET_STORAGE_TOPIC: debezium_offset
-      STATUS_STORAGE_TOPIC: debezium_status
-    volumes:
-      - ./kafka:/kafka/config
-  web:
-    build: .
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    env_file: .env
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
     volumes:
       - .:/app
-    environment:
-      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/budget
-      CELERY_BROKER_URL: redis://redis:6379/0
-      CELERY_RESULT_BACKEND: redis://redis:6379/0
-      KAFKA_BROKER_URL: kafka:9092
-      CLICKHOUSE_HOST: clickhouse
-      VAULT_ADDR: http://vault:8200
-    ports:
-      - "8000:8000"
+    env_file: .env
     depends_on:
       - db
       - redis
       - kafka
-      - vault
-  worker:
-    build: .
-    command: celery -A app.tasks worker --loglevel=info
-    volumes:
-      - .:/app
-    environment:
-      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/budget
-      CELERY_BROKER_URL: redis://redis:6379/0
-      CELERY_RESULT_BACKEND: redis://redis:6379/0
-      CLICKHOUSE_HOST: clickhouse
-      VAULT_ADDR: http://vault:8200
-    depends_on:
-      - db
-      - redis
-      - kafka
-      - vault
-  notify_worker:
-    build: .
-    command: python -m app.tasks.notify_worker
-    volumes:
-      - .:/app
-    environment:
-      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/budget
-      CELERY_BROKER_URL: redis://redis:6379/0
-      CELERY_RESULT_BACKEND: redis://redis:6379/0
-      CLICKHOUSE_HOST: clickhouse
-      VAULT_ADDR: http://vault:8200
-    depends_on:
-      - db
-      - redis
-      - kafka
-      - vault
-
-  bank_import:
-    build: .
-    command: python services/bank_import/main.py
-    volumes:
-      - .:/app
-    environment:
-      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/budget
-      KAFKA_BROKER_URL: kafka:9092
-      CLICKHOUSE_HOST: clickhouse
-      VAULT_ADDR: http://vault:8200
-    depends_on:
-      - db
-      - kafka
-  airflow:
-    image: apache/airflow:2.9.3
-    depends_on:
-      - kafka
-      - clickhouse
-    ports:
-      - "8080:8080"
-    volumes:
-      - ./ml/dags:/opt/airflow/dags
-      - airflow_logs:/opt/airflow/logs
-    environment:
-      AIRFLOW__CORE__EXECUTOR: LocalExecutor
-      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: sqlite:////opt/airflow/airflow.db
-      AIRFLOW__CORE__FERNET_KEY: dummyfernetkey123
-      KAFKA_BROKER_URL: kafka:9092
-      CLICKHOUSE_HOST: clickhouse
-      MLFLOW_TRACKING_URI: http://mlflow:5000
-    command: >-
-      bash -c "airflow db upgrade && airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com && airflow webserver"
-  mlflow:
-    image: ghcr.io/mlflow/mlflow:v2.10.0
-    ports:
-      - "5000:5000"
-    volumes:
-      - mlflow_data:/mlflow
-    command: mlflow server --backend-store-uri sqlite:///mlflow.db --default-artifact-root /mlflow --host 0.0.0.0
-  predictor:
-    build: .
-    command: uvicorn services/predictor.main:app --host 0.0.0.0 --port 8000
-    volumes:
-      - .:/app
-    environment:
-      MLFLOW_TRACKING_URI: http://mlflow:5000
-    ports:
-      - "8001:8000"
-    depends_on:
-      - mlflow
-  clickhouse:
-    image: clickhouse/clickhouse-server:23.3
-    ports:
-      - "8123:8123"
-    environment:
-      CLICKHOUSE_DB: budget
-    volumes:
-      - clickhouse_data:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 volumes:
   db_data:
-  clickhouse_data:
-  airflow_logs:
-  mlflow_data:


### PR DESCRIPTION
## Summary
- add Dockerfile for backend build
- simplify docker-compose.yml with only core services

## Testing
- `pre-commit run --files docker-compose.yml .env backend/Dockerfile`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68644cdc1294832da736c95c4dd474be