### PR TITLE
Move Dockerfile to backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM python:3.12-slim
-WORKDIR /app
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ curl -X POST "http://127.0.0.1:8000/пользователи/join" \
 docker-compose up --build
 ```
 
+Docker build configuration resides in `backend/Dockerfile`.
+
 API будет доступно по адресу `http://localhost:8000`.
 
 ## Миграции


### PR DESCRIPTION
## Summary
- remove root Dockerfile and keep it inside `backend/`
- mention the new Dockerfile location in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686454f1ad30832da2ded8bb5d7fd04f