### PR TITLE
Fix CI mypy path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
+          pip install -r requirements.txt
           pip install -r backend/requirements-dev.txt
           pip install ruff==0.12.1 black==25.1.0 pytest
       - name: Ruff lint
@@ -22,6 +23,6 @@ jobs:
       - name: Black check
         run: black --check .
       - name: Mypy check
-        run: mypy backend
+        run: mypy app
       - name: Run tests
         run: pytest


### PR DESCRIPTION
## Summary
- install backend requirements and main requirements together in CI
- run mypy on the `app` folder instead of the non-existent `backend` sources

## Testing
- `ruff check --output-format=github .`
- `black --check .`
- `mypy app`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68645f4635f8832dafb54f48c65fcac3