### PR TITLE
Fix ruff import error

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,5 @@
-import importlib, sys
-_backend_app = importlib.import_module('backend.app')
+import importlib
+import sys
+
+_backend_app = importlib.import_module("backend.app")
 sys.modules[__name__] = _backend_app


### PR DESCRIPTION
## Summary
- fix ruff error by splitting imports in `app/__init__.py`

## Testing
- `pre-commit run --files app/__init__.py`
- `ruff check --output-format=github app/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68646d3d6604832dbdf478a21113a30e