### PR TITLE
Add CodeQL job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,11 @@ jobs:
         run: mypy backend/app
       - name: Run tests
         run: pytest backend/tests
+
+  codeql:
+    permissions: read-all
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- run GitHub CodeQL analysis in CI

## Testing
- `make ci` *(fails: ruff unrecognized subcommand)*

------
https://chatgpt.com/codex/tasks/task_e_6864fcfa18ac832dbbd7ef0f4b4a1f59