### PR TITLE
Add Semgrep job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v3
       - uses: github/codeql-action/analyze@v3
+  semgrep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: returntocorp/semgrep-action@v1
+        with:
+          config: auto


### PR DESCRIPTION
## Summary
- run semgrep in CI using `returntocorp/semgrep-action@v1`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_6865029bae64832daaa8bd67699a019b