### PR TITLE
Fix CodeQL upload permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
         run: pytest backend/tests
 
   codeql:
-    permissions: read-all
+    permissions:
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant `security-events: write` to the CodeQL job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_6865135f0c0c832db51cb77174626675