### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: "/frontend/web"
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: "/frontend/pwa"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- enable dependabot for pip and npm in frontend

## Testing
- `ruff check .`
- `black --check .`
- `mypy backend/app`

------
https://chatgpt.com/codex/tasks/task_e_6865384cb888832db04de34ad5e8d433