### PR TITLE
Fix ruff invocation in lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ dev:
 	docker-compose up --build
 
 lint:
-	ruff .
+	ruff check .
 	black --check .
 	mypy backend/app
 


### PR DESCRIPTION
## Summary
- update `ruff` invocation in `Makefile`

## Testing
- `pre-commit run --files Makefile`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68653c4dec70832db444adf73a19ff9f