### PR TITLE
Update docs with new tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ make dev  # запускает docker-compose и открывает http://local
 make ci   # локальный запуск ruff, black, mypy и pytest
 ```
 
+Для работы в [devcontainer](https://containers.dev/) предусмотрена команда
+
+```bash
+make devcontainer
+```
+
 Полные примеры запросов смотрите в [docs/examples.md](docs/examples.md). Инструкции по развёртыванию доступны в [docs/deployment.md](docs/deployment.md).
 
 ## Структура проекта
@@ -23,6 +29,14 @@ make ci   # локальный запуск ruff, black, mypy и pytest
 - `frontend/web` — веб-клиент на Next.js
 - `services/` — дополнительные сервисы
 - `docs/` — документация
+
+## Дополнительные зависимости
+
+Для проверки кода в репозитории настроены [pre-commit](https://pre-commit.com/) 
+хуки. Установите их командой `pre-commit install`, а затем используйте
+`pre-commit run --all-files` перед созданием pull request.
+
+В CI выполняется анализ безопасности исходного кода с помощью CodeQL.
 
 ## Вклад
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,6 +14,8 @@ terraform apply
 
 Укажите значения переменных `yc_token`, `yc_cloud_id`, `yc_folder_id`, `yc_network_id` и при необходимости `yc_zone` в соответствии со своей учётной записью.
 
+Для проверки конфигураций Terraform можно запускать `tfsec` или `terrascan`.
+
 ## Развёртывание приложения с Helm
 
 В каталоге `infra/helm` находится Helm-чарт. Получив kubeconfig для кластера, установите чарт:


### PR DESCRIPTION
## Summary
- mention devcontainer start command
- add note about pre-commit hooks and CodeQL
- mention using tfsec/terrascan when deploying

## Testing
- `make ci` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686547ddfe60832dade2ca626ef0cb6c