### PR TITLE
Add tfsec and terrascan to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,17 @@ repos:
     rev: v8.18.1
     hooks:
       - id: gitleaks
+
+  - repo: https://github.com/aquasecurity/tfsec
+    rev: v1.28.14
+    hooks:
+      - id: tfsec
+        args: [infra/terraform]
+        pass_filenames: false
+
+  - repo: https://github.com/tenable/terrascan
+    rev: v1.19.9
+    hooks:
+      - id: terraform-pre-commit
+        args: [--, infra/terraform]
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- add security scanning hooks for tfsec and terrascan
- target the infra/terraform directory

## Testing
- `pre-commit run --files infra/terraform/main.tf tfsec terraform-pre-commit` *(fails: `terrascan` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654cf80e44832dbf3e1b349f5002cf