### PR TITLE
Update Ruff version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
         language_version: python3.12
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.12.1
     hooks:
       - id: ruff
         args: [--fix]

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,4 +1,4 @@
-ruff==0.4.4
+ruff==0.12.1
 black==24.3.0
 mypy==1.10.0
 pytest


### PR DESCRIPTION
## Summary
- use Ruff `0.12.1` in development requirements
- update `ruff-pre-commit` hook revision to `v0.12.1`
- verify CI installs Ruff `0.12.1`

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68654ef0dbf4832db900bd90c3e057ee