### PR TITLE
Fix import order for ruff

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from .routers import (
 )
 from .database import engine, Base
 from .kafka_producer import close as close_producer
+from contextlib import asynccontextmanager
 
 tags_metadata = [
     {"name": "Категории", "description": "Управление категориями операций"},
@@ -37,8 +38,6 @@ tags_metadata = [
     {"name": "Валюты", "description": "Курсы и конвертация"},
     {"name": "Уведомления", "description": "Web Push подписки"},
 ]
-
-from contextlib import asynccontextmanager
 
 
 @asynccontextmanager


### PR DESCRIPTION
## Summary
- move `asynccontextmanager` import to the top of `main.py`

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError for 'fastapi' and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68658977a878832d8cd0de9259834b57