### PR TITLE
Remove obsolete app alias

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -4,7 +4,7 @@ import os
 from alembic import context  # type: ignore[attr-defined]
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.engine import make_url
-from app.models import Base
+from backend.app.models import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,0 @@
-import importlib
-import sys
-
-_backend_app = importlib.import_module("backend.app")
-sys.modules[__name__] = _backend_app

--- a/backend/tests/test_banks.py
+++ b/backend/tests/test_banks.py
@@ -71,7 +71,7 @@ def test_import_with_saved_token(monkeypatch):
         vault.get_vault_client.cache_clear()
         monkeypatch.setattr(vault, "get_vault_client", lambda: fake_vault)
         monkeypatch.setattr(
-            "app.routers.banks.get_connector",
+            "backend.app.routers.banks.get_connector",
             lambda b, uid, token=None: FakeConnector(uid, token),
         )
 

--- a/services/bank_import/main.py
+++ b/services/bank_import/main.py
@@ -11,7 +11,7 @@ from aiokafka import AIOKafkaConsumer
 BASE_DIR = Path(__file__).resolve().parents[2]
 sys.path.append(str(BASE_DIR))  # noqa: E402
 
-from app import banks, crud, database  # noqa: E402
+from backend.app import banks, crud, database  # noqa: E402
 
 KAFKA_BROKER_URL = os.getenv("KAFKA_BROKER_URL", "localhost:9092")
 TOPIC = os.getenv("BANK_TOPIC", "bank.raw")


### PR DESCRIPTION
## Summary
- drop alias package `app`
- import backend app directly in alembic and bank import service
- update tests for new import path

## Testing
- `pre-commit run --all-files` *(fails: terraform-pre-commit not found)*
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_68658a9ea7e0832dba59e6ccd2e7816d