### PR TITLE
Add ledger service and tests

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -81,6 +81,23 @@ class Transaction(TransactionBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class PostingBase(BaseModel):
+    amount: float
+    side: str
+    account_id: UUID
+
+
+class PostingCreate(PostingBase):
+    pass
+
+
+class Posting(PostingBase):
+    id: UUID
+    transaction_id: UUID
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class GoalBase(BaseModel):
     """Основные поля цели накоплений."""
 

--- a/backend/app/services/ledger.py
+++ b/backend/app/services/ledger.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import AsyncGenerator
+from uuid import UUID
+
+from sqlalchemy import select, func, case
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models, schemas, currency
+
+
+async def post_entry(
+    db: AsyncSession,
+    txn: schemas.TransactionCreate,
+    postings: list[schemas.PostingCreate],
+    account_id: UUID,
+    user_id: UUID,
+) -> models.Transaction:
+    """Insert transaction and postings atomically."""
+    async with db.begin():
+        rate = await currency.get_rate(txn.currency)
+        tx_data = txn.model_dump(exclude_unset=True)
+        created = tx_data.get("created_at")
+        if created is None:
+            created = datetime.now().replace(tzinfo=None)
+        elif created.tzinfo is not None:
+            created = created.replace(tzinfo=None)
+        tx_data["created_at"] = created
+        tx_obj = models.Transaction(
+            **tx_data,
+            amount_rub=txn.amount * rate,
+            account_id=account_id,
+            user_id=user_id,
+        )
+        db.add(tx_obj)
+        await db.flush()
+        for item in postings:
+            db.add(
+                models.Posting(
+                    amount=item.amount,
+                    side=item.side,
+                    account_id=item.account_id,
+                    transaction_id=tx_obj.id,
+                )
+            )
+    await db.refresh(tx_obj)
+    return tx_obj
+
+
+async def get_balance(
+    db: AsyncSession,
+    account_id: UUID,
+    at: datetime | None = None,
+) -> float:
+    """Return account balance at moment `at`."""
+    stmt = (
+        select(
+            func.coalesce(
+                func.sum(
+                    case(
+                        (models.Posting.side == models.PostingSide.debit, models.Posting.amount),
+                        else_=-models.Posting.amount,
+                    )
+                ),
+                0,
+            )
+        )
+        .join(models.Transaction)
+        .where(models.Posting.account_id == account_id)
+    )
+    if at:
+        stmt = stmt.where(models.Transaction.created_at <= at)
+    result = await db.execute(stmt)
+    return float(result.scalar() or 0)
+
+
+async def stream_transactions(
+    db: AsyncSession,
+    account_id: UUID,
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> AsyncGenerator[models.Transaction, None]:
+    """Yield transactions one by one ordered by date."""
+    stmt = select(models.Transaction).where(models.Transaction.account_id == account_id)
+    if start:
+        stmt = stmt.where(models.Transaction.created_at >= start)
+    if end:
+        stmt = stmt.where(models.Transaction.created_at < end)
+    stmt = stmt.order_by(models.Transaction.created_at)
+    result = await db.stream_scalars(stmt)
+    async for row in result:
+        yield row

--- a/backend/tests/test_ledger.py
+++ b/backend/tests/test_ledger.py
@@ -1,0 +1,143 @@
+import os
+import sys
+from pathlib import Path
+import uuid
+import pytest
+from sqlalchemy import select, func, text
+import pytest_asyncio
+
+# add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from backend.app import database, models, schemas
+from backend.app.services import ledger
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db():
+    # store previous engine and session maker
+    old_engine = database.engine
+    old_sessionmaker = database.async_session
+    old_url = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = "postgresql+asyncpg://testuser:testpass@localhost/testuserdb"
+
+    await old_engine.dispose()
+    from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+    database.engine = create_async_engine(os.environ["DATABASE_URL"], echo=False)
+    database.async_session = async_sessionmaker(database.engine, expire_on_commit=False)
+
+    async with database.engine.begin() as conn:
+        await conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+        await conn.execute(text("CREATE SCHEMA public"))
+        await conn.run_sync(database.Base.metadata.create_all)
+        uid = uuid.uuid4()
+        await conn.execute(
+            text(
+                "INSERT INTO currencies(id, code, name, symbol, precision) "
+                "VALUES(:id, 'RUB', 'Ruble', '₽', 2)"
+            ),
+            {"id": uid},
+        )
+        await conn.execute(
+            text(
+                """
+                CREATE OR REPLACE FUNCTION check_postings_balance()
+                RETURNS TRIGGER AS $$
+                DECLARE
+                    txid uuid;
+                    deb NUMERIC;
+                    cred NUMERIC;
+                BEGIN
+                    IF TG_OP = 'DELETE' THEN
+                        txid := OLD.transaction_id;
+                    ELSE
+                        txid := NEW.transaction_id;
+                    END IF;
+                    SELECT COALESCE(SUM(amount) FILTER (WHERE side='debit'), 0),
+                           COALESCE(SUM(amount) FILTER (WHERE side='credit'), 0)
+                    INTO deb, cred
+                    FROM postings WHERE transaction_id = txid;
+                    IF deb <> cred THEN
+                        RAISE EXCEPTION 'Debit and credit totals do not match for transaction %', txid;
+                    END IF;
+                    IF TG_OP = 'DELETE' THEN
+                        RETURN OLD;
+                    ELSE
+                        RETURN NEW;
+                    END IF;
+                END;
+                $$ LANGUAGE plpgsql;
+                """
+            )
+        )
+        await conn.execute(
+            text(
+                """
+                CREATE CONSTRAINT TRIGGER postings_balance_check
+                AFTER INSERT OR UPDATE OR DELETE ON postings
+                DEFERRABLE INITIALLY DEFERRED
+                FOR EACH ROW EXECUTE FUNCTION check_postings_balance()
+                """
+            )
+        )
+    yield
+    async with database.engine.begin() as conn:
+        await conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+        await conn.execute(text("CREATE SCHEMA public"))
+    await database.engine.dispose()
+    database.engine = old_engine
+    database.async_session = old_sessionmaker
+    if old_url is not None:
+        os.environ["DATABASE_URL"] = old_url
+
+
+async def _prepare_entities(session: AsyncSession):
+    acc1 = models.Account(name='Cash', currency_code='RUB')
+    acc2 = models.Account(name='Income', currency_code='RUB')
+    user = models.User(email='u@example.com', hashed_password='x', account=acc1)
+    cat = models.Category(name='Misc', account=acc1, user=user)
+    session.add_all([acc1, acc2, user, cat])
+    await session.commit()
+    return acc1, acc2, user, cat
+
+
+@pytest.mark.asyncio
+async def test_post_entry_and_stream():
+    async with database.async_session() as session:
+        acc1, acc2, user, cat = await _prepare_entities(session)
+        tx = schemas.TransactionCreate(amount=100, currency='RUB', category_id=cat.id)
+        postings = [
+            schemas.PostingCreate(amount=100, side='debit', account_id=acc1.id),
+            schemas.PostingCreate(amount=100, side='credit', account_id=acc2.id),
+        ]
+        await ledger.post_entry(session, tx, postings, acc1.id, user.id)
+
+        bal1 = await ledger.get_balance(session, acc1.id)
+        bal2 = await ledger.get_balance(session, acc2.id)
+        assert bal1 == 100
+        assert bal2 == -100
+
+        rows = []
+        async for item in ledger.stream_transactions(session, acc1.id):
+            rows.append(item)
+        assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_entry_atomicity():
+    async with database.async_session() as session:
+        acc1, acc2, user, cat = await _prepare_entities(session)
+        tx = schemas.TransactionCreate(amount=100, currency='RUB', category_id=cat.id)
+        postings = [
+            schemas.PostingCreate(amount=100, side='debit', account_id=acc1.id),
+            schemas.PostingCreate(amount=50, side='credit', account_id=acc2.id),
+        ]
+        with pytest.raises(Exception):
+            await ledger.post_entry(session, tx, postings, acc1.id, user.id)
+
+        count_tx = await session.scalar(select(func.count()).select_from(models.Transaction))
+        count_post = await session.scalar(select(func.count()).select_from(models.Posting))
+        assert count_tx == 0
+        assert count_post == 0


### PR DESCRIPTION
## Summary
- implement a ledger service with posting support
- extend schemas with posting models
- add async unit tests for ledger service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b1bc7e74832d8c55253efb277c31