### PR TITLE
Fix formatting for ledger service and tests

### DIFF
--- a/backend/app/services/ledger.py
+++ b/backend/app/services/ledger.py
@@ -59,7 +59,10 @@ async def get_balance(
             func.coalesce(
                 func.sum(
                     case(
-                        (models.Posting.side == models.PostingSide.debit, models.Posting.amount),
+                        (
+                            models.Posting.side == models.PostingSide.debit,
+                            models.Posting.amount,
+                        ),
                         else_=-models.Posting.amount,
                     )
                 ),


### PR DESCRIPTION
## Summary
- run black formatting on backend/app/services/ledger.py
- run black formatting on backend/tests/test_ledger.py

## Testing
- `make lint`
- `make test` *(fails: OSError connecting to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6865b6b6b74c832d9f081484e4461750