### PR TITLE
Add pytest-asyncio to dev requirements

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -2,4 +2,5 @@ ruff==0.12.1
 black==24.3.0
 mypy==1.10.0
 pytest
+pytest-asyncio
 commitizen


### PR DESCRIPTION
## Summary
- fix failing tests by installing `pytest-asyncio`

## Testing
- `pip install -r requirements.txt`
- `pip install -r backend/requirements-dev.txt`
- `pytest backend/tests` *(fails: OSError Multiple exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_6865b9342510832d8c26fa5490620780