### PR TITLE
Fix Makefile tab usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ test:
 ci: lint test
 
 devcontainer:
-        devcontainer up --workspace-folder .
+	devcontainer up --workspace-folder .
 
 proto:
-        python -m grpc_tools.protoc -I proto --python_out=backend/app/grpc \
-                --grpclib_python_out=backend/app/grpc proto/ledger.proto
+	python -m grpc_tools.protoc -I proto --python_out=backend/app/grpc \
+	--grpclib_python_out=backend/app/grpc proto/ledger.proto


### PR DESCRIPTION
## Summary
- fix spaces vs tab indentation in Makefile for `devcontainer` and `proto` rules

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686650624a24832dad7b7faeb4bd329d