### PR TITLE
Fix failing tests

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -3,4 +3,5 @@ black==24.3.0
 mypy==1.10.0
 pytest
 pytest-asyncio
+asgi_lifespan
 commitizen


### PR DESCRIPTION
## Summary
- add `asgi_lifespan` to dev requirements so pytest can import `LifespanManager`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686681caf1e8832d95fb1a2520062427