### PR TITLE
Add coverage and openapi jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r backend/requirements-dev.txt
-          pip install ruff==0.12.1 black==25.1.0 pytest
+          pip install ruff==0.12.1 black==25.1.0 pytest pytest-cov
       - name: Run linters
         run: make lint
       - name: Run tests
-        run: pytest backend/tests
+        run: pytest --cov=backend --cov-fail-under=90 backend/tests
 
   codeql:
     permissions:
@@ -39,3 +39,23 @@ jobs:
       - uses: returntocorp/semgrep-action@v1
         with:
           config: auto
+
+  openapi:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Generate OpenAPI spec
+        run: make openapi
+      - name: Commit updated spec
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update openapi spec'
+          file_pattern: docs/api/openapi.yaml

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -3,5 +3,6 @@ black==24.3.0
 mypy==1.10.0
 pytest
 pytest-asyncio
+pytest-cov
 asgi_lifespan
 commitizen


### PR DESCRIPTION
## Summary
- enforce 90% coverage in CI
- autogenerate and commit OpenAPI spec
- add pytest-cov to dev requirements

## Testing
- `pytest -q`
- `pytest --cov=backend --cov-fail-under=90 backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_6866842b80fc832db7f50bcd39c75423