### PR TITLE
Add demo user script and update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: dev ci lint test devcontainer proto openapi
+.PHONY: dev ci lint test devcontainer proto openapi demo_user
+
 
 dev:
 	python -m webbrowser http://localhost:8000/docs &
@@ -23,3 +24,6 @@ proto:
 
 openapi:
 	python -m backend.scripts.generate_openapi
+
+demo_user:
+	python -m backend.scripts.create_demo_user

--- a/README.md
+++ b/README.md
@@ -17,6 +17,26 @@ make ci   # локальный запуск ruff, black, mypy и pytest
 make devcontainer
 ```
 
+### Миграции и документация
+
+Перед первым запуском выполните миграции базы данных:
+
+```bash
+alembic upgrade head
+```
+
+Файл OpenAPI можно сгенерировать командой:
+
+```bash
+make openapi
+```
+
+Для создания демонстрационного пользователя выполните:
+
+```bash
+make demo_user
+```
+
 Полные примеры запросов смотрите в [docs/examples.md](docs/examples.md). Инструкции по развёртыванию доступны в [docs/deployment.md](docs/deployment.md).
 
 ## Структура проекта
@@ -29,6 +49,20 @@ make devcontainer
 - `frontend/web` — веб-клиент на Next.js
 - `services/` — дополнительные сервисы
 - `docs/` — документация
+
+## gRPC
+
+Сервис LedgerService можно запустить командой:
+
+```bash
+python -m backend.app.grpc.server
+```
+
+Пример запроса с использованием `grpcurl`:
+
+```bash
+grpcurl -plaintext -d '{"account_id":"<uuid>"}' localhost:50051 ledger.LedgerService.GetBalance
+```
 
 ## Дополнительные зависимости
 

--- a/backend/app/grpc/server.py
+++ b/backend/app/grpc/server.py
@@ -101,3 +101,15 @@ def serve(host: str = "0.0.0.0", port: int = 50051) -> Server:
     service = LedgerService()
     server = Server([service])
     return server
+
+
+async def _main(host: str = "0.0.0.0", port: int = 50051) -> None:
+    server = serve()
+    await server.start(host, port)
+    await server.wait_closed()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(_main())

--- a/backend/scripts/create_demo_user.py
+++ b/backend/scripts/create_demo_user.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from backend.app import crud, schemas, database
+
+
+async def main() -> None:
+    async with database.async_session() as session:
+        existing = await crud.get_user_by_email(session, "demo@fintrack.dev")
+        if existing:
+            print("User already exists: demo@fintrack.dev")
+            return
+        user = schemas.UserCreate(email="demo@fintrack.dev", password="ChangeMe!123")
+        await crud.create_user(session, user)
+        print("Demo user created: demo@fintrack.dev / ChangeMe!123")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -17,11 +17,11 @@ uvicorn backend.app.main:app --reload
 ## Создание пользователя и получение токена
 
 ```bash
-curl -X POST "http://127.0.0.1:8000/пользователи/" \
+curl -X POST "http://127.0.0.1:8000/users/" \
      -H "Content-Type: application/json" \
      -d '{"email": "me@example.com", "password": "secret"}'
 
-curl -X POST "http://127.0.0.1:8000/пользователи/token" \
+curl -X POST "http://127.0.0.1:8000/users/token" \
      -d "username=me@example.com&password=secret" \
      -H "Content-Type: application/x-www-form-urlencoded"
 ```
@@ -29,7 +29,7 @@ curl -X POST "http://127.0.0.1:8000/пользователи/token" \
 ## Создание категории с лимитом
 
 ```bash
-curl -X POST "http://127.0.0.1:8000/категории/" \
+curl -X POST "http://127.0.0.1:8000/categories/" \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json" \
      -d '{"name": "Продукты", "monthly_limit": 15000}'
@@ -40,7 +40,7 @@ curl -X POST "http://127.0.0.1:8000/категории/" \
 CSV-файл должен содержать колонки `amount`, `currency`, `description`, `category_id` и опционально `created_at` в ISO-формате.
 
 ```bash
-curl -X POST "http://127.0.0.1:8000/операции/импорт" \
+curl -X POST "http://127.0.0.1:8000/transactions/import" \
      -H "Authorization: Bearer <token>" \
      -F "file=@transactions.csv"
 ```
@@ -48,7 +48,7 @@ curl -X POST "http://127.0.0.1:8000/операции/импорт" \
 ## Получить операции за период
 
 ```bash
-curl "http://127.0.0.1:8000/операции/?start=2025-06-01T00:00:00&end=2025-06-30T23:59:59" \
+curl "http://127.0.0.1:8000/transactions/?start=2025-06-01T00:00:00&end=2025-06-30T23:59:59" \
      -H "Authorization: Bearer <token>"
 ```
 Можно указать `category_id`, чтобы вывести операции только по конкретной категории.
@@ -100,7 +100,7 @@ curl -X POST "http://127.0.0.1:8000/банки/импорт" \
 ## Присоединиться к счёту
 
 ```bash
-curl -X POST "http://127.0.0.1:8000/пользователи/join" \
+curl -X POST "http://127.0.0.1:8000/users/join" \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json" \
      -d '{"account_id": 1}'


### PR DESCRIPTION
## Summary
- add script and Makefile target to create demo user
- document migrations, OpenAPI generation, gRPC usage
- refresh API examples with new routes
- expose runnable gRPC server

## Testing
- `pre-commit run --files Makefile README.md backend/app/grpc/server.py docs/examples.md backend/scripts/create_demo_user.py` *(fails: terrascan not configured)*
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68668abf20a8832da76bdb3d819c10db