### PR TITLE
Add tinkoff mock auth endpoint

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -67,3 +67,17 @@ async def refresh(
     access = security.create_access_token({"sub": email})
     refresh = security.create_refresh_token({"sub": email})
     return {"access_token": access, "refresh_token": refresh, "token_type": "bearer"}
+
+
+MOCK_EMAIL = "mock@tinkoff.dev"
+
+
+@router.get("/tinkoff/mock", response_model=schemas.Token)
+async def tinkoff_mock(session: AsyncSession = Depends(database.get_session)) -> dict:
+    """Выдать JWT для фиктивного пользователя Тинькофф."""
+    email = MOCK_EMAIL
+    user = await crud.get_user_by_email(session, email)
+    if not user:
+        user = await crud.create_user_oauth(session, email)
+    token = security.create_access_token({"sub": user.email})
+    return {"access_token": token, "token_type": "bearer"}

--- a/backend/tests/test_auth_mock.py
+++ b/backend/tests/test_auth_mock.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+DB_PATH = Path("test.db")
+if DB_PATH.exists():
+    DB_PATH.unlink()
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test.db"
+
+from backend.app.main import app  # noqa: E402
+
+
+def test_tinkoff_mock_login():
+    with TestClient(app) as client:
+        r = client.get("/auth/tinkoff/mock")
+        assert r.status_code == 200
+        token = r.json()["access_token"]
+
+        headers = {"Authorization": f"Bearer {token}"}
+        r = client.get("/users/me", headers=headers)
+        assert r.status_code == 200
+        assert r.json()["email"] == "mock@tinkoff.dev"


### PR DESCRIPTION
## Summary
- add `/auth/tinkoff/mock` to issue JWT for a fixed email
- create test covering mock auth flow

## Testing
- `ruff check .`
- `black --check .`
- `mypy backend/app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cb3092fc832dab2efadec1f41661