### PR TITLE
Unify error responses

### DIFF
--- a/backend/app/api/utils.py
+++ b/backend/app/api/utils.py
@@ -1,0 +1,8 @@
+from fastapi import HTTPException
+
+
+def api_error(status_code: int, detail: str, code: str) -> HTTPException:
+    """Helper to create HTTP errors with code."""
+    return HTTPException(
+        status_code=status_code, detail={"detail": detail, "code": code}
+    )

--- a/backend/app/api/v1/accounts.py
+++ b/backend/app/api/v1/accounts.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid import UUID
 
 from ... import crud, database, schemas
 from ...models import User
 from ...services import ledger
+from ..utils import api_error
 from .users import get_current_user
 
 router = APIRouter(prefix="/accounts", tags=["Счёт"])
@@ -18,10 +19,7 @@ async def create_account(
 ):
     """Создать счёт."""
     if current_user.role == "readonly":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"detail": "Forbidden", "code": "FORBIDDEN"},
-        )
+        raise api_error(status.HTTP_403_FORBIDDEN, "Forbidden", "FORBIDDEN")
     if data.user_id is None:
         data.user_id = current_user.id
     account = await crud.create_account(session, data)
@@ -45,10 +43,7 @@ async def read_account(
     """Вернуть информацию о текущем счёте."""
     account = await crud.get_account(session, current_user.account_id)
     if not account:
-        raise HTTPException(
-            status_code=404,
-            detail={"detail": "Account not found", "code": "ACCOUNT_NOT_FOUND"},
-        )
+        raise api_error(404, "Account not found", "ACCOUNT_NOT_FOUND")
     return account
 
 
@@ -59,16 +54,18 @@ async def update_account(
     session: AsyncSession = Depends(database.get_session),
 ):
     """Изменить параметры текущего счёта."""
+    if data.currency_code is not None:
+        existing = await crud.get_account(session, current_user.account_id)
+        if existing and existing.currency_code != data.currency_code:
+            raise api_error(400, "Account currency immutable", "CURRENCY_IMMUTABLE")
+
     account = await crud.update_account(
         session,
         current_user.account_id,
         **data.model_dump(exclude_unset=True),
     )
     if not account:
-        raise HTTPException(
-            status_code=404,
-            detail={"detail": "Account not found", "code": "ACCOUNT_NOT_FOUND"},
-        )
+        raise api_error(404, "Account not found", "ACCOUNT_NOT_FOUND")
     return account
 
 
@@ -81,10 +78,7 @@ async def read_one_account(
     """Получить счёт по идентификатору."""
     account = await crud.get_account(session, account_id)
     if not account:
-        raise HTTPException(
-            status_code=404,
-            detail={"detail": "Account not found", "code": "ACCOUNT_NOT_FOUND"},
-        )
+        raise api_error(404, "Account not found", "ACCOUNT_NOT_FOUND")
     return account
 
 
@@ -97,18 +91,17 @@ async def update_one_account(
 ):
     """Обновить счёт."""
     if current_user.role == "readonly":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"detail": "Forbidden", "code": "FORBIDDEN"},
-        )
+        raise api_error(status.HTTP_403_FORBIDDEN, "Forbidden", "FORBIDDEN")
+    if data.currency_code is not None:
+        existing = await crud.get_account(session, account_id)
+        if existing and existing.currency_code != data.currency_code:
+            raise api_error(400, "Account currency immutable", "CURRENCY_IMMUTABLE")
+
     account = await crud.update_account(
         session, account_id, **data.model_dump(exclude_unset=True)
     )
     if not account:
-        raise HTTPException(
-            status_code=404,
-            detail={"detail": "Account not found", "code": "ACCOUNT_NOT_FOUND"},
-        )
+        raise api_error(404, "Account not found", "ACCOUNT_NOT_FOUND")
     return account
 
 
@@ -120,16 +113,10 @@ async def delete_account(
 ):
     """Удалить счёт."""
     if current_user.role in {"readonly", "member"}:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"detail": "Forbidden", "code": "FORBIDDEN"},
-        )
+        raise api_error(status.HTTP_403_FORBIDDEN, "Forbidden", "FORBIDDEN")
     ok = await crud.delete_account(session, account_id)
     if not ok:
-        raise HTTPException(
-            status_code=404,
-            detail={"detail": "Account not found", "code": "ACCOUNT_NOT_FOUND"},
-        )
+        raise api_error(404, "Account not found", "ACCOUNT_NOT_FOUND")
     return None
 
 

--- a/backend/app/api/v1/categories.py
+++ b/backend/app/api/v1/categories.py
@@ -1,10 +1,11 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ... import crud, schemas, database
 from ...models import User
+from ..utils import api_error
 from .users import get_current_user
 
 router = APIRouter(prefix="/categories", tags=["Категории"])
@@ -27,10 +28,7 @@ async def create_category(
 ):
     """Создать новую категорию."""
     if current_user.role == "readonly":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"detail": "Forbidden", "code": "FORBIDDEN"},
-        )
+        raise api_error(status.HTTP_403_FORBIDDEN, "Forbidden", "FORBIDDEN")
     return await crud.create_category(
         session, category, current_user.account_id, current_user.id
     )
@@ -45,10 +43,7 @@ async def read_category(
     """Получить категорию по идентификатору."""
     category = await crud.get_category(session, category_id, current_user.account_id)
     if not category:
-        raise HTTPException(
-            status_code=404,
-            detail={"detail": "Category not found", "code": "CATEGORY_NOT_FOUND"},
-        )
+        raise api_error(404, "Category not found", "CATEGORY_NOT_FOUND")
     return category
 
 
@@ -61,18 +56,12 @@ async def update_category(
 ):
     """Обновить категорию."""
     if current_user.role == "readonly":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"detail": "Forbidden", "code": "FORBIDDEN"},
-        )
+        raise api_error(status.HTTP_403_FORBIDDEN, "Forbidden", "FORBIDDEN")
     category = await crud.update_category(
         session, category_id, data, current_user.account_id
     )
     if not category:
-        raise HTTPException(
-            status_code=404,
-            detail={"detail": "Category not found", "code": "CATEGORY_NOT_FOUND"},
-        )
+        raise api_error(404, "Category not found", "CATEGORY_NOT_FOUND")
     return category
 
 
@@ -84,14 +73,8 @@ async def delete_category(
 ):
     """Удалить категорию."""
     if current_user.role == "readonly":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"detail": "Forbidden", "code": "FORBIDDEN"},
-        )
+        raise api_error(status.HTTP_403_FORBIDDEN, "Forbidden", "FORBIDDEN")
     success = await crud.delete_category(session, category_id, current_user.account_id)
     if not success:
-        raise HTTPException(
-            status_code=409,
-            detail={"detail": "Category has transactions", "code": "CATEGORY_IN_USE"},
-        )
+        raise api_error(409, "Category has transactions", "CATEGORY_IN_USE")
     return None

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import JWTError, jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ... import crud, schemas, database, security
 from ...models import User
+from ..utils import api_error
 
 router = APIRouter(prefix="/users", tags=["Пользователи"])
 
@@ -26,15 +27,11 @@ async def get_current_user(
         )
         email: str = payload.get("sub")
     except JWTError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail={"detail": "Invalid token", "code": "INVALID_TOKEN"},
-        )
+        raise api_error(status.HTTP_401_UNAUTHORIZED, "Invalid token", "INVALID_TOKEN")
     user = await crud.get_user_by_email(session, email)
     if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail={"detail": "User not found", "code": "USER_NOT_FOUND"},
+        raise api_error(
+            status.HTTP_401_UNAUTHORIZED, "User not found", "USER_NOT_FOUND"
         )
     return user
 
@@ -46,10 +43,7 @@ async def create_user(
     """Зарегистрировать нового пользователя."""
     db_user = await crud.get_user_by_email(session, user.email)
     if db_user:
-        raise HTTPException(
-            status_code=400,
-            detail={"detail": "Email already registered", "code": "EMAIL_EXISTS"},
-        )
+        raise api_error(400, "Email already registered", "EMAIL_EXISTS")
     return await crud.create_user(session, user)
 
 
@@ -62,10 +56,7 @@ async def join_account(
     """Присоединиться к существующему счёту."""
     user = await crud.join_account(session, current_user, data.account_id)
     if not user:
-        raise HTTPException(
-            status_code=404,
-            detail={"detail": "Account not found", "code": "ACCOUNT_NOT_FOUND"},
-        )
+        raise api_error(404, "Account not found", "ACCOUNT_NOT_FOUND")
     return user
 
 
@@ -86,16 +77,10 @@ async def remove_user(
 ):
     """Удалить пользователя из счёта."""
     if current_user.role != "owner" and current_user.id != user_id:
-        raise HTTPException(
-            status_code=403,
-            detail={"detail": "Forbidden", "code": "FORBIDDEN"},
-        )
+        raise api_error(403, "Forbidden", "FORBIDDEN")
     ok = await crud.delete_user(session, user_id, current_user.account_id)
     if not ok:
-        raise HTTPException(
-            status_code=404,
-            detail={"detail": "User not found", "code": "USER_NOT_FOUND"},
-        )
+        raise api_error(404, "User not found", "USER_NOT_FOUND")
     return None
 
 
@@ -109,12 +94,10 @@ async def login(
     if not user or not security.verify_password(
         form_data.password, user.hashed_password
     ):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail={
-                "detail": "Incorrect username or password",
-                "code": "INVALID_CREDENTIALS",
-            },
+        raise api_error(
+            status.HTTP_401_UNAUTHORIZED,
+            "Incorrect username or password",
+            "INVALID_CREDENTIALS",
         )
     access_token = security.create_access_token({"sub": user.email})
     return {"access_token": access_token, "token_type": "bearer"}

--- a/backend/app/routers/banks.py
+++ b/backend/app/routers/banks.py
@@ -3,10 +3,11 @@
 from datetime import datetime
 
 import os
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import database, crud
+from ..api.utils import api_error
 from ..models import User
 from ..api.v1.users import get_current_user
 from ..banks import get_connector
@@ -44,11 +45,11 @@ async def import_from_bank(
     try:
         connector = get_connector(bank, current_user.id, token)
     except ValueError:
-        raise HTTPException(status_code=400, detail="Неизвестный банк")
+        raise api_error(400, "Неизвестный банк", "UNKNOWN_BANK")
 
     transactions = await connector.fetch_transactions(start, end)
     if not transactions:
-        raise HTTPException(status_code=400, detail="Не удалось получить операции")
+        raise api_error(400, "Не удалось получить операции", "BANK_FETCH_ERROR")
     await crud.create_transactions_bulk(
         session, transactions, current_user.account_id, current_user.id
     )
@@ -66,7 +67,7 @@ async def import_using_saved_token(
     """Импортировать операции, используя сохранённый токен банка."""
     token_obj = await crud.get_bank_token(session, bank, current_user.id)
     if not token_obj:
-        raise HTTPException(status_code=404, detail="Токен не найден")
+        raise api_error(404, "Токен не найден", "TOKEN_NOT_FOUND")
     if USE_KAFKA:
         await publish(
             KAFKA_TOPIC,
@@ -83,10 +84,10 @@ async def import_using_saved_token(
     try:
         connector = get_connector(bank, current_user.id)
     except ValueError:
-        raise HTTPException(status_code=400, detail="Неизвестный банк")
+        raise api_error(400, "Неизвестный банк", "UNKNOWN_BANK")
     transactions = await connector.fetch_transactions(start, end)
     if not transactions:
-        raise HTTPException(status_code=400, detail="Не удалось получить операции")
+        raise api_error(400, "Не удалось получить операции", "BANK_FETCH_ERROR")
     await crud.create_transactions_bulk(
         session, transactions, current_user.account_id, current_user.id
     )

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -1,9 +1,10 @@
 """Маршруты для целей накоплений."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, schemas, database
+from ..api.utils import api_error
 from ..models import User
 from ..api.v1.users import get_current_user
 import uuid
@@ -41,7 +42,7 @@ async def read_goal(
     """Получить цель по ID."""
     goal = await crud.get_goal(session, goal_id, current_user.account_id)
     if not goal:
-        raise HTTPException(status_code=404, detail="Цель не найдена")
+        raise api_error(404, "Цель не найдена", "GOAL_NOT_FOUND")
     return goal
 
 
@@ -55,7 +56,7 @@ async def update_goal(
     """Изменить параметры цели."""
     goal = await crud.update_goal(session, goal_id, data, current_user.account_id)
     if not goal:
-        raise HTTPException(status_code=404, detail="Цель не найдена")
+        raise api_error(404, "Цель не найдена", "GOAL_NOT_FOUND")
     return goal
 
 
@@ -71,7 +72,7 @@ async def deposit_goal(
         session, goal_id, data.amount, current_user.account_id
     )
     if not goal:
-        raise HTTPException(status_code=404, detail="Цель не найдена")
+        raise api_error(404, "Цель не найдена", "GOAL_NOT_FOUND")
     return goal
 
 

--- a/backend/app/routers/jobs.py
+++ b/backend/app/routers/jobs.py
@@ -1,9 +1,10 @@
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import tasks, database, crud
+from ..api.utils import api_error
 from ..models import User
 from ..api.v1.users import get_current_user
 
@@ -23,7 +24,7 @@ async def import_transactions_job(
     if token is None:
         token_obj = await crud.get_bank_token(session, bank, current_user.id)
         if not token_obj:
-            raise HTTPException(status_code=404, detail="Токен не найден")
+            raise api_error(404, "Токен не найден", "TOKEN_NOT_FOUND")
     result = tasks.import_transactions_task.delay(
         bank,
         token,

--- a/backend/app/routers/oauth.py
+++ b/backend/app/routers/oauth.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import database, crud, security, oauth
 from .. import schemas
+from ..api.utils import api_error
 
 router = APIRouter(prefix="/oauth", tags=["OAuth"])
 
@@ -22,7 +23,7 @@ async def tinkoff_callback(
     try:
         email = await oauth.exchange_code(code)
     except Exception as exc:  # pragma: no cover - network errors
-        raise HTTPException(status_code=400, detail="OAuth error") from exc
+        raise api_error(400, "OAuth error", "OAUTH_ERROR") from exc
     user = await crud.get_user_by_email(session, email)
     if not user:
         user = await crud.create_user_oauth(session, email)

--- a/backend/app/routers/recurring.py
+++ b/backend/app/routers/recurring.py
@@ -1,10 +1,11 @@
 """Маршруты для регулярных платежей."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 import uuid
 
 from .. import crud, schemas, database
+from ..api.utils import api_error
 from ..models import User
 from ..api.v1.users import get_current_user
 
@@ -41,7 +42,7 @@ async def read_recurring_payment(
     """Получить регулярный платеж по ID."""
     rp = await crud.get_recurring_payment(session, rp_id, current_user.account_id)
     if not rp:
-        raise HTTPException(status_code=404, detail="Платёж не найден")
+        raise api_error(404, "Платёж не найден", "PAYMENT_NOT_FOUND")
     return rp
 
 
@@ -57,7 +58,7 @@ async def update_recurring_payment(
         session, rp_id, data, current_user.account_id
     )
     if not rp:
-        raise HTTPException(status_code=404, detail="Платёж не найден")
+        raise api_error(404, "Платёж не найден", "PAYMENT_NOT_FOUND")
     return rp
 
 

--- a/backend/app/routers/tinkoff.py
+++ b/backend/app/routers/tinkoff.py
@@ -2,10 +2,11 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import database, crud
+from ..api.utils import api_error
 from ..models import User
 from ..api.v1.users import get_current_user
 from ..banks.tinkoff import TinkoffConnector
@@ -25,7 +26,7 @@ async def import_tinkoff(
     connector = TinkoffConnector(token)
     transactions = await connector.fetch_transactions(start, end)
     if not transactions:
-        raise HTTPException(status_code=400, detail="Не удалось получить операции")
+        raise api_error(400, "Не удалось получить операции", "BANK_FETCH_ERROR")
     await crud.create_transactions_bulk(
         session, transactions, current_user.account_id, current_user.id
     )


### PR DESCRIPTION
## Summary
- implement `api_error` helper
- use it in routers and API v1 modules
- block account currency change

## Testing
- `ruff check backend/app/api/utils.py backend/app/routers/banks.py backend/app/routers/goals.py backend/app/routers/recurring.py backend/app/routers/jobs.py backend/app/routers/oauth.py backend/app/routers/tinkoff.py backend/app/api/v1/accounts.py backend/app/api/v1/categories.py backend/app/api/v1/transactions.py backend/app/api/v1/auth.py backend/app/api/v1/users.py`
- `black backend/app/api/utils.py backend/app/routers/banks.py backend/app/routers/goals.py backend/app/routers/recurring.py backend/app/routers/jobs.py backend/app/routers/oauth.py backend/app/routers/tinkoff.py backend/app/api/v1/accounts.py backend/app/api/v1/categories.py backend/app/api/v1/transactions.py backend/app/api/v1/auth.py backend/app/api/v1/users.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asgi_lifespan')*

------
https://chatgpt.com/codex/tasks/task_e_6866d1247870832d95222b389723ef80