### PR TITLE
Add extensive tests for ledger and auth

### DIFF
--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,24 +1,32 @@
-import os
-from pathlib import Path
 import sys
+from pathlib import Path
 import pytest
-from httpx import AsyncClient
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
 from asgi_lifespan import LifespanManager
 
+# import backend after adjusting path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-db_path = Path("test.db")
-if db_path.exists():
-    db_path.unlink()
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test.db"
+import backend.app.api.v1.auth as auth_v1
+import backend.app.api.v1.users as users_v1
+from backend.app.database import engine, Base
 
-from backend.app.main import app  # noqa: E402
+app = FastAPI()
+app.include_router(auth_v1.router)
+app.include_router(users_v1.router)
+
+@app.on_event("startup")
+async def startup() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
 
 
 @pytest.mark.asyncio
 async def test_jwt_cycle():
     async with LifespanManager(app):
-        async with AsyncClient(app=app, base_url="http://test") as client:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
             user = {"email": "jwt@example.com", "password": "Password123$"}
             r = await client.post("/auth/signup", json=user)
             assert r.status_code == 200
@@ -36,3 +44,31 @@ async def test_jwt_cycle():
             headers = {"Authorization": f"Bearer {new_token}"}
             r = await client.get("/users/me", headers=headers)
             assert r.status_code == 200
+            r = await client.get("/auth/tinkoff/mock")
+            assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_signup_duplicate():
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            data = {"email": "dup@example.com", "password": "Password123$"}
+            r = await client.post("/auth/signup", json=data)
+            assert r.status_code == 200
+            r = await client.post("/auth/signup", json=data)
+            assert r.status_code == 400
+
+@pytest.mark.asyncio
+async def test_update_user_me():
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            data = {"email": "update@example.com", "password": "Password123$"}
+            await client.post("/auth/signup", json=data)
+            r = await client.post("/auth/login", json=data)
+            token = r.json()["access_token"]
+            headers = {"Authorization": f"Bearer {token}"}
+            r = await client.patch("/users/me", json={"email": "changed@example.com"}, headers=headers)
+            assert r.status_code == 200
+            assert r.json()["email"] == "changed@example.com"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+import pytest_asyncio
+
+# add repository root to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# ensure DATABASE_URL is set before backend modules import
+DB_PATH = Path("test.db")
+if DB_PATH.exists():
+    DB_PATH.unlink()
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test.db"
+
+from backend.app.database import engine, async_session, Base
+
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    await engine.dispose()
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+
+@pytest_asyncio.fixture
+async def session():
+    async with async_session() as s:
+        yield s

--- a/tests/grpc/test_ledger_grpc.py
+++ b/tests/grpc/test_ledger_grpc.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+import pytest
+from grpclib.testing import ChannelFor
+from google.protobuf.timestamp_pb2 import Timestamp
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "backend" / "app" / "grpc"))
+
+from backend.app import models, schemas, crud, currency
+from backend.app.grpc import ledger_grpc, ledger_pb2, server
+
+
+@pytest.mark.asyncio
+async def test_grpc_post_entry(session, monkeypatch):
+    user = await crud.create_user(session, schemas.UserCreate(email="g@e.com", password="Pwd123$"))
+    category = await crud.create_category(session, schemas.CategoryCreate(name="Food"), user.account_id, user.id)
+
+    async def fake_rate(code: str) -> float:
+        return 1.0
+
+    monkeypatch.setattr(currency, "get_rate", fake_rate)
+
+    service = server.LedgerService()
+    async with ChannelFor([service]) as channel:
+        stub = ledger_grpc.LedgerServiceStub(channel)
+        req = ledger_pb2.PostEntryRequest(
+            amount=50,
+            currency="RUB",
+            description="test",
+            category_id=str(category.id),
+            account_id=str(user.account_id),
+            user_id=str(user.id),
+            postings=[],
+        )
+        resp = await stub.PostEntry(req)
+        assert resp.id
+
+        bal = await stub.GetBalance(ledger_pb2.BalanceRequest(account_id=str(user.account_id)))
+        assert bal.amount == 0
+
+        txns = await stub.StreamTxns(
+            ledger_pb2.StreamRequest(account_id=str(user.account_id))
+        )
+        assert len(txns) == 1
+        assert txns[0].id == resp.id
+

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,22 @@
+import pytest
+
+from backend.app import models
+
+
+def test_account_currency_immutable():
+    acc = models.Account(name="Test", currency_code="RUB")
+    with pytest.raises(ValueError):
+        acc.currency_code = "USD"
+
+
+from datetime import datetime, timezone
+
+
+def test_transaction_created_at_tz():
+    tx = models.Transaction(
+        amount=10,
+        currency="RUB",
+        amount_rub=10,
+        created_at=datetime.now(timezone.utc),
+    )
+    assert tx.created_at.tzinfo is not None

--- a/tests/unit/test_services_ledger.py
+++ b/tests/unit/test_services_ledger.py
@@ -1,0 +1,32 @@
+import asyncio
+import pytest
+
+from backend.app import models, schemas, crud, currency
+from backend.app.database import async_session
+from backend.app.services import ledger
+
+
+@pytest.mark.asyncio
+async def test_post_entry_and_balance(session, monkeypatch):
+    user = await crud.create_user(session, schemas.UserCreate(email="a@b.c", password="Pwd123$"))
+    category = await crud.create_category(
+        session, schemas.CategoryCreate(name="Food"), user.account_id, user.id
+    )
+
+    async def fake_rate(code: str) -> float:
+        return 1.0
+
+    monkeypatch.setattr(currency, "get_rate", fake_rate)
+
+    txn = schemas.TransactionCreate(amount=100, currency="RUB", category_id=category.id)
+    postings: list[schemas.PostingCreate] = []
+    async with async_session() as db:
+        tx = await ledger.post_entry(db, txn, postings, user.account_id, user.id)
+        assert tx.amount == 100
+
+        balance = await ledger.get_balance(db, user.account_id)
+        assert balance == 0
+
+        txns = [t async for t in ledger.stream_transactions(db, user.account_id)]
+    assert len(txns) == 1
+    assert txns[0].id == tx.id


### PR DESCRIPTION
## Summary
- create test database fixtures
- extend auth API tests
- add unit tests for models and ledger service
- add gRPC tests for ledger

## Testing
- `pytest --cov=backend tests`

------
https://chatgpt.com/codex/tasks/task_e_6866d561a954832db1a5e556553be323