### PR TITLE
Update db schema and fix tests

### DIFF
--- a/backend/app/grpc/ledger_grpc.py
+++ b/backend/app/grpc/ledger_grpc.py
@@ -10,7 +10,7 @@ if typing.TYPE_CHECKING:
     import grpclib.server
 
 import google.protobuf.timestamp_pb2
-import ledger_pb2
+from . import ledger_pb2
 
 
 class LedgerServiceBase(abc.ABC):

--- a/backend/tests/test_accounts.py
+++ b/backend/tests/test_accounts.py
@@ -41,10 +41,16 @@ async def test_account_read_and_update():
                 json={"id": data["id"], "name": "Семейный", "currency_code": "USD"},
                 headers=headers,
             )
+            assert r.status_code == 400
+
+            r = await client.patch(
+                "/accounts/me",
+                json={"id": data["id"], "name": "Семейный"},
+                headers=headers,
+            )
             assert r.status_code == 200
             result = r.json()
             assert result["name"] == "Семейный"
-            assert result["currency_code"] == "USD"
 
             r = await client.get(f"/accounts/{data['id']}/balance", headers=headers)
             assert r.status_code == 200

--- a/docs/architecture/db-schema.puml
+++ b/docs/architecture/db-schema.puml
@@ -8,6 +8,12 @@ entity accounts {
   *id UUID
   user_id UUID
 }
+entity currencies {
+  *code VARCHAR(3)
+  name
+  symbol
+  precision
+}
 entity categories {
   *id UUID
   parent_id UUID
@@ -60,6 +66,8 @@ accounts ||--o{ goals
 accounts ||--o{ recurring_payments
 accounts ||--o{ bank_tokens
 accounts ||--o{ push_subscriptions
+currencies ||--o{ accounts
+currencies ||--o{ postings
 categories ||--o{ transactions
 categories ||--o{ recurring_payments
 categories ||--o{ categories : parent


### PR DESCRIPTION
## Summary
- fix relative import in generated gRPC client
- adjust account tests for immutable currency
- document currencies table in db schema

## Testing
- `pytest --cov=backend --cov-fail-under=90 backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6866d9bc8380832d8ae4b605b819ea13