### PR TITLE
Update pydantic requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 Небольшой FastAPI-бекенд для учёта доходов, расходов и целей накоплений. Все примеры и интерфейс на русском языке.
 
+## Установка зависимостей
+
+```bash
+pip install -r requirements.txt
+pip install -r backend/requirements-dev.txt  # для разработки
+```
+
 ## Быстрый старт
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]
 SQLAlchemy>=2.0
 email-validator>=2.0
 asyncpg
-pydantic
+pydantic>=2.0
 alembic
 python-dotenv
 passlib[bcrypt]==1.7.4


### PR DESCRIPTION
## Summary
- pin pydantic>=2.0 in requirements
- document installing dependencies in README

## Testing
- `make ci` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866e46702a0832daf73135fd9d3433d