### PR TITLE
Add postings to transactions and ledger checks

### DIFF
--- a/backend/app/api/v1/transactions.py
+++ b/backend/app/api/v1/transactions.py
@@ -21,6 +21,7 @@ from fastapi import (
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ... import crud, schemas, database
+from ...services import ledger
 from ...models import User
 from ..utils import api_error
 from .users import get_current_user
@@ -57,9 +58,10 @@ async def create_transaction(
     """Создать новую операцию."""
     if current_user.role == "readonly":
         raise api_error(status.HTTP_403_FORBIDDEN, "Forbidden", "FORBIDDEN")
-    return await crud.create_transaction(
+    return await ledger.post_entry(
         session,
         tx,
+        tx.postings,
         current_user.account_id,
         current_user.id,
     )

--- a/backend/app/schemas/posting.py
+++ b/backend/app/schemas/posting.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 STRICT = ConfigDict(strict=True)
 ORM_STRICT = ConfigDict(from_attributes=True, strict=True)
@@ -12,6 +12,10 @@ class PostingBase(BaseModel):
     currency_code: str | None = None
 
     model_config = STRICT
+
+    @field_validator("account_id", mode="before")
+    def _validate_account_id(cls, v):
+        return UUID(str(v))
 
 
 class PostingCreate(PostingBase):

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from uuid import UUID
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .posting import PostingCreate
 
 STRICT = ConfigDict(strict=True)
 ORM_STRICT = ConfigDict(from_attributes=True, strict=True)
@@ -22,6 +24,7 @@ class TransactionBase(BaseModel):
 
 class TransactionCreate(TransactionBase):
     created_at: datetime | None = None
+    postings: list[PostingCreate] = Field(default_factory=list)
 
     model_config = STRICT
 

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -31,6 +31,11 @@ def test_analytics_endpoints():
         token = _login(client)
         headers = {"Authorization": f"Bearer {token}"}
 
+        acc = client.get("/accounts/me", headers=headers).json()
+        r = client.post("/accounts/", json={"name": "Income"}, headers=headers)
+        assert r.status_code == 200
+        acc2 = r.json()["id"]
+
         # create category
         r = client.post(
             "/categories/", json={"name": "Еда", "monthly_limit": 200}, headers=headers
@@ -45,6 +50,10 @@ def test_analytics_endpoints():
             "description": "Магазин",
             "category_id": cat_id,
             "created_at": "2025-06-05T12:00:00",
+            "postings": [
+                {"amount": 100, "side": "debit", "account_id": acc["id"]},
+                {"amount": 100, "side": "credit", "account_id": acc2},
+            ],
         }
         tx2 = {
             "amount": 50,
@@ -52,6 +61,10 @@ def test_analytics_endpoints():
             "description": "Кафе",
             "category_id": cat_id,
             "created_at": "2025-06-15T12:00:00",
+            "postings": [
+                {"amount": 50, "side": "debit", "account_id": acc["id"]},
+                {"amount": 50, "side": "credit", "account_id": acc2},
+            ],
         }
         client.post("/transactions/", json=tx1, headers=headers)
         client.post("/transactions/", json=tx2, headers=headers)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2515,6 +2515,29 @@ components:
       - forecast
       title: MonthlySummary
       description: Итог и прогноз расходов за месяц.
+    PostingCreate:
+      properties:
+        amount:
+          type: number
+          title: Amount
+        side:
+          type: string
+          title: Side
+        account_id:
+          type: string
+          format: uuid
+          title: Account Id
+        currency_code:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Currency Code
+      type: object
+      required:
+      - amount
+      - side
+      - account_id
+      title: PostingCreate
     PushSubscription:
       properties:
         endpoint:
@@ -2790,6 +2813,11 @@ components:
             format: date-time
           - type: 'null'
           title: Created At
+        postings:
+          items:
+            $ref: '#/components/schemas/PostingCreate'
+          type: array
+          title: Postings
       type: object
       required:
       - amount

--- a/tests/unit/test_services_ledger.py
+++ b/tests/unit/test_services_ledger.py
@@ -1,4 +1,5 @@
 import pytest
+from fastapi import HTTPException
 
 from backend.app import schemas, crud, currency
 from backend.app.database import async_session
@@ -19,15 +20,41 @@ async def test_post_entry_and_balance(session, monkeypatch):
 
     monkeypatch.setattr(currency, "get_rate", fake_rate)
 
+    # create second account for postings
+    account2 = await crud.create_account(
+        session,
+        schemas.AccountCreate(name="Income", currency_code="RUB", user_id=user.id),
+    )
+
     txn = schemas.TransactionCreate(amount=100, currency="RUB", category_id=category.id)
-    postings: list[schemas.PostingCreate] = []
+    postings = [
+        schemas.PostingCreate(amount=100, side="debit", account_id=user.account_id),
+        schemas.PostingCreate(amount=100, side="credit", account_id=account2.id),
+    ]
     async with async_session() as db:
         tx = await ledger.post_entry(db, txn, postings, user.account_id, user.id)
         assert tx.amount == 100
 
         balance = await ledger.get_balance(db, user.account_id)
-        assert balance == 0
+        assert balance == 100
 
         txns = [t async for t in ledger.stream_transactions(db, user.account_id)]
     assert len(txns) == 1
     assert txns[0].id == tx.id
+
+
+@pytest.mark.asyncio
+async def test_post_entry_requires_two_postings(session):
+    user = await crud.create_user(
+        session, schemas.UserCreate(email="b@b.c", password="Pwd123$")
+    )
+    category = await crud.create_category(
+        session, schemas.CategoryCreate(name="Misc"), user.account_id, user.id
+    )
+    txn = schemas.TransactionCreate(amount=50, currency="RUB", category_id=category.id)
+    postings = [
+        schemas.PostingCreate(amount=50, side="debit", account_id=user.account_id)
+    ]
+    async with async_session() as db:
+        with pytest.raises(HTTPException):
+            await ledger.post_entry(db, txn, postings, user.account_id, user.id)


### PR DESCRIPTION
## Summary
- extend `TransactionCreate` with `postings` field
- use `ledger.post_entry` in transactions API
- validate postings list size in ledger service
- ensure posting account IDs parse correctly
- update ledger service to handle nested sessions and set posting currency
- regenerate OpenAPI
- adjust tests for new postings requirement

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6866f25974d4832d9ba38e01d798e382