### PR TITLE
Fix formatting for ledger tests

### DIFF
--- a/tests/unit/test_services_ledger.py
+++ b/tests/unit/test_services_ledger.py
@@ -101,4 +101,3 @@ async def test_post_entry_mismatched_totals(session):
     async with async_session() as db:
         with pytest.raises(Exception):
             await ledger.post_entry(db, txn, postings, user.account_id, user.id)
-


### PR DESCRIPTION
## Summary
- apply `black` formatting to `tests/unit/test_services_ledger.py`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6866fcd0d5b0832d96d5d0a0f006905f