### PR TITLE
Rename transaction query parameters

### DIFF
--- a/backend/app/api/v1/transactions.py
+++ b/backend/app/api/v1/transactions.py
@@ -31,8 +31,8 @@ router = APIRouter(prefix="/transactions", tags=["Операции"])
 
 @router.get("/", response_model=list[schemas.Transaction])
 async def read_transactions(
-    start: datetime | None = Query(None, description="Start date"),
-    end: datetime | None = Query(None, description="End date"),
+    date_from: datetime | None = Query(None, description="Start date"),
+    date_to: datetime | None = Query(None, description="End date"),
     category_id: str | None = Query(None, description="Category"),
     limit: int | None = Query(None, description="Limit"),
     session: AsyncSession = Depends(database.get_session),
@@ -42,8 +42,8 @@ async def read_transactions(
     return await crud.get_transactions(
         session,
         current_user.account_id,
-        start=start,
-        end=end,
+        date_from=date_from,
+        date_to=date_to,
         category_id=category_id,
         limit=limit,
     )
@@ -124,8 +124,8 @@ async def import_transactions(
 
 @router.get("/export")
 async def export_transactions(
-    start: datetime | None = Query(None, description="Start date"),
-    end: datetime | None = Query(None, description="End date"),
+    date_from: datetime | None = Query(None, description="Start date"),
+    date_to: datetime | None = Query(None, description="End date"),
     category_id: str | None = Query(None, description="Category"),
     session: AsyncSession = Depends(database.get_session),
     current_user: User = Depends(get_current_user),
@@ -134,8 +134,8 @@ async def export_transactions(
     rows = await crud.get_transactions(
         session,
         current_user.account_id,
-        start=start,
-        end=end,
+        date_from=date_from,
+        date_to=date_to,
         category_id=category_id,
     )
     fieldnames = [

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -265,16 +265,16 @@ async def delete_category(
 async def get_transactions(
     db: AsyncSession,
     account_id: uuid.UUID,
-    start: datetime | None = None,
-    end: datetime | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
     category_id: uuid.UUID | None = None,
     limit: int | None = None,
 ):
     stmt = select(models.Transaction).where(models.Transaction.account_id == account_id)
-    if start:
-        stmt = stmt.where(models.Transaction.created_at >= start)
-    if end:
-        stmt = stmt.where(models.Transaction.created_at < end)
+    if date_from:
+        stmt = stmt.where(models.Transaction.created_at >= date_from)
+    if date_to:
+        stmt = stmt.where(models.Transaction.created_at < date_to)
     if category_id:
         stmt = stmt.where(models.Transaction.category_id == category_id)
     stmt = stmt.order_by(

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -150,7 +150,7 @@ paths:
       security:
       - OAuth2PasswordBearer: []
       parameters:
-      - name: start
+      - name: date_from
         in: query
         required: false
         schema:
@@ -159,9 +159,9 @@ paths:
             format: date-time
           - type: 'null'
           description: Start date
-          title: Start
+          title: Date From
         description: Start date
-      - name: end
+      - name: date_to
         in: query
         required: false
         schema:
@@ -170,7 +170,7 @@ paths:
             format: date-time
           - type: 'null'
           description: End date
-          title: End
+          title: Date To
         description: End date
       - name: category_id
         in: query
@@ -272,7 +272,7 @@ paths:
       security:
       - OAuth2PasswordBearer: []
       parameters:
-      - name: start
+      - name: date_from
         in: query
         required: false
         schema:
@@ -281,9 +281,9 @@ paths:
             format: date-time
           - type: 'null'
           description: Start date
-          title: Start
+          title: Date From
         description: Start date
-      - name: end
+      - name: date_to
         in: query
         required: false
         schema:
@@ -292,7 +292,7 @@ paths:
             format: date-time
           - type: 'null'
           description: End date
-          title: End
+          title: Date To
         description: End date
       - name: category_id
         in: query

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -48,7 +48,7 @@ curl -X POST "http://127.0.0.1:8000/transactions/import" \
 ## Получить операции за период
 
 ```bash
-curl "http://127.0.0.1:8000/transactions/?start=2025-06-01T00:00:00&end=2025-06-30T23:59:59" \
+curl "http://127.0.0.1:8000/transactions/?date_from=2025-06-01T00:00:00&date_to=2025-06-30T23:59:59" \
      -H "Authorization: Bearer <token>"
 ```
 Можно указать `category_id`, чтобы вывести операции только по конкретной категории.


### PR DESCRIPTION
## Summary
- rename `start`/`end` parameters to `date_from`/`date_to`
- update related crud logic
- document new parameters in OpenAPI and examples

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6866ffbe1888832da3fe6e935b048b45