### PR TITLE
Add health check endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,7 @@ tags_metadata = [
     {"name": "Auth", "description": "Signup and JWT auth"},
     {"name": "Валюты", "description": "Курсы и конвертация"},
     {"name": "Уведомления", "description": "Web Push подписки"},
+    {"name": "Сервис", "description": "Системные маршруты"},
 ]
 
 
@@ -80,3 +81,9 @@ app.include_router(oauth.router)
 app.include_router(auth_v1.router)
 app.include_router(currencies_v1.router)
 app.include_router(push.router)
+
+
+@app.get("/health", tags=["Сервис"])
+async def health() -> dict[str, str]:
+    """Проверка работоспособности приложения."""
+    return {"status": "ok"}

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2004,6 +2004,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /health:
+    get:
+      tags:
+      - Сервис
+      summary: Health
+      description: Проверка работоспособности приложения.
+      operationId: health_health_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+                title: Response Health Health Get
 components:
   schemas:
     Account:
@@ -2973,3 +2990,5 @@ tags:
   description: Курсы и конвертация
 - name: Уведомления
   description: Web Push подписки
+- name: Сервис
+  description: Системные маршруты

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -1,0 +1,15 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from asgi_lifespan import LifespanManager
+
+from backend.app.main import app
+
+
+@pytest.mark.asyncio
+async def test_health():
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/health")
+            assert response.status_code == 200
+            assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add `/health` route returning `{"status": "ok"}`
- document new route in the OpenAPI specification
- add tests for the new endpoint

## Testing
- `pytest tests/api -q`


------
https://chatgpt.com/codex/tasks/task_e_68677f97deec832da886e11c7b8578a2