### PR TITLE
Switch to TimescaleDB image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   db:
-    image: postgres:16
+    image: timescale/timescaledb:2-postgis-16
     env_file: .env
     volumes:
       - db_data:/var/lib/postgresql/data


### PR DESCRIPTION
## Summary
- use TimescaleDB image for Postgres service

## Testing
- `make lint`
- `mypy backend/app`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68679a05914c832da9780760114d9b1c