### PR TITLE
Fix ledger post_entry

### DIFF
--- a/backend/app/services/ledger.py
+++ b/backend/app/services/ledger.py
@@ -28,8 +28,11 @@ async def post_entry(
     started = not db.in_transaction()
     ctx = db.begin() if started else contextlib.nullcontext()
     async with ctx:
-        tx_data = txn.model_dump(exclude_unset=True)
-        tx_data.pop("postings", None)
+        tx_data = {
+            k: v
+            for k, v in txn.model_dump(exclude_unset=True).items()
+            if k in {"posted_at", "payee", "note", "external_id"}
+        }
         posted = tx_data.get("posted_at")
         if posted is None:
             posted = datetime.now().replace(tzinfo=None)

--- a/backend/tests/test_ledger.py
+++ b/backend/tests/test_ledger.py
@@ -120,7 +120,7 @@ async def _prepare_entities(session: AsyncSession):
 async def test_post_entry_and_stream():
     async with database.async_session() as session:
         acc1, acc2, user, cat = await _prepare_entities(session)
-        tx = schemas.TransactionCreate(amount=100, currency="RUB", category_id=cat.id)
+        tx = schemas.TransactionCreate(category_id=cat.id)
         postings = [
             schemas.PostingCreate(amount=100, side="debit", account_id=acc1.id),
             schemas.PostingCreate(amount=100, side="credit", account_id=acc2.id),
@@ -142,7 +142,7 @@ async def test_post_entry_and_stream():
 async def test_post_entry_atomicity():
     async with database.async_session() as session:
         acc1, acc2, user, cat = await _prepare_entities(session)
-        tx = schemas.TransactionCreate(amount=100, currency="RUB", category_id=cat.id)
+        tx = schemas.TransactionCreate(category_id=cat.id)
         postings = [
             schemas.PostingCreate(amount=100, side="debit", account_id=acc1.id),
             schemas.PostingCreate(amount=50, side="credit", account_id=acc2.id),


### PR DESCRIPTION
## Summary
- update ledger entry logic to store only transaction metadata
- adjust ledger tests for new schema

## Testing
- `pre-commit run --files backend/app/services/ledger.py backend/tests/test_ledger.py`
- `pytest backend/tests/test_ledger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c76c0450832d9d464ff19f932f2e