### PR TITLE
Update transaction endpoints and docs

### DIFF
--- a/backend/app/api/v1/transactions.py
+++ b/backend/app/api/v1/transactions.py
@@ -31,8 +31,8 @@ router = APIRouter(prefix="/transactions", tags=["Операции"])
 
 @router.get("/", response_model=list[schemas.Transaction])
 async def read_transactions(
-    date_from: datetime | None = Query(None, description="Start date"),
-    date_to: datetime | None = Query(None, description="End date"),
+    date_from: datetime | None = Query(None, description="Start date (posted_at)"),
+    date_to: datetime | None = Query(None, description="End date (posted_at)"),
     category_id: str | None = Query(None, description="Category"),
     limit: int | None = Query(None, description="Limit"),
     session: AsyncSession = Depends(database.get_session),
@@ -123,8 +123,8 @@ async def import_transactions(
 
 @router.get("/export")
 async def export_transactions(
-    date_from: datetime | None = Query(None, description="Start date"),
-    date_to: datetime | None = Query(None, description="End date"),
+    date_from: datetime | None = Query(None, description="Start date (posted_at)"),
+    date_to: datetime | None = Query(None, description="End date (posted_at)"),
     category_id: str | None = Query(None, description="Category"),
     session: AsyncSession = Depends(database.get_session),
     current_user: User = Depends(get_current_user),

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -68,12 +68,28 @@ def test_notification_stream():
             )
             cat_id = r.json()["id"]
 
+            base_acc = client.get("/accounts/me", headers=headers).json()
+            r = client.post("/accounts/", json={"name": "Income"}, headers=headers)
+            acc2_id = r.json()["id"]
+
             tx = {
-                "amount": 150,
-                "currency": "RUB",
-                "description": "Магазин",
+                "payee": "Магазин",
+                "posted_at": "2025-06-15T12:00:00",
                 "category_id": cat_id,
-                "created_at": "2025-06-15T12:00:00",
+                "postings": [
+                    {
+                        "amount": 150,
+                        "side": "debit",
+                        "account_id": base_acc["id"],
+                        "currency_code": "RUB",
+                    },
+                    {
+                        "amount": 150,
+                        "side": "credit",
+                        "account_id": acc2_id,
+                        "currency_code": "RUB",
+                    },
+                ],
             }
             client.post("/transactions/", json=tx, headers=headers)
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -158,9 +158,9 @@ paths:
           - type: string
             format: date-time
           - type: 'null'
-          description: Start date
+          description: Start date (posted_at)
           title: Date From
-        description: Start date
+        description: Start date (posted_at)
       - name: date_to
         in: query
         required: false
@@ -169,9 +169,9 @@ paths:
           - type: string
             format: date-time
           - type: 'null'
-          description: End date
+          description: End date (posted_at)
           title: Date To
-        description: End date
+        description: End date (posted_at)
       - name: category_id
         in: query
         required: false
@@ -280,9 +280,9 @@ paths:
           - type: string
             format: date-time
           - type: 'null'
-          description: Start date
+          description: Start date (posted_at)
           title: Date From
-        description: Start date
+        description: Start date (posted_at)
       - name: date_to
         in: query
         required: false
@@ -291,9 +291,9 @@ paths:
           - type: string
             format: date-time
           - type: 'null'
-          description: End date
+          description: End date (posted_at)
           title: Date To
-        description: End date
+        description: End date (posted_at)
       - name: category_id
         in: query
         required: false

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -37,7 +37,7 @@ curl -X POST "http://127.0.0.1:8000/categories/" \
 
 ## Импорт операций из CSV
 
-CSV-файл должен содержать колонки `amount`, `currency`, `description`, `category_id` и опционально `created_at` в ISO-формате.
+CSV-файл должен содержать колонки `payee`, `note`, `category_id` и опционально `posted_at` в ISO-формате.
 
 ```bash
 curl -X POST "http://127.0.0.1:8000/transactions/import" \


### PR DESCRIPTION
## Summary
- tweak transactions endpoints to clarify date filters
- update notification test for new transaction fields
- refresh example docs and OpenAPI spec

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68697c892134832d9556ba4d6dc011bb