### PR TITLE
Update auto-commit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Generate OpenAPI spec
         run: make openapi
       - name: Commit updated spec
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: EndBug/add-and-commit@v9
         with:
-          commit_message: 'chore: update openapi spec'
-          file_pattern: docs/api/openapi.yaml
+          message: 'chore: update openapi spec [skip ci]'
+          add: docs/api/openapi.yaml


### PR DESCRIPTION
## Summary
- update OpenAPI auto-commit step to use EndBug/add-and-commit
- confirm `generate-openapi` pre-commit hook

## Testing
- `pre-commit run generate-openapi --files docs/api/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68697f7c49e4832db60d2252c6e63fbf