### PR TITLE
Update tests for transaction and ledger logic

### DIFF
--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -28,7 +28,7 @@ async def test_jwt_cycle():
     async with LifespanManager(app):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            user = {"email": "jwt@example.com", "password": "Password123$"}
+            user = {"email": "jwt@example.com", "password": "ComplexPass123$"}
             r = await client.post("/auth/signup", json=user)
             assert r.status_code == 200
             r = await client.post("/auth/login", json=user)
@@ -54,7 +54,7 @@ async def test_signup_duplicate():
     async with LifespanManager(app):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            data = {"email": "dup@example.com", "password": "Password123$"}
+            data = {"email": "dup@example.com", "password": "ComplexPass123$"}
             r = await client.post("/auth/signup", json=data)
             assert r.status_code == 200
             r = await client.post("/auth/signup", json=data)
@@ -66,7 +66,7 @@ async def test_update_user_me():
     async with LifespanManager(app):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            data = {"email": "update@example.com", "password": "Password123$"}
+            data = {"email": "update@example.com", "password": "ComplexPass123$"}
             await client.post("/auth/signup", json=data)
             r = await client.post("/auth/login", json=data)
             token = r.json()["access_token"]

--- a/tests/grpc/test_ledger_grpc.py
+++ b/tests/grpc/test_ledger_grpc.py
@@ -14,7 +14,7 @@ from backend.app.grpc import ledger_grpc, ledger_pb2, server
 @pytest.mark.asyncio
 async def test_grpc_post_entry(session, monkeypatch):
     user = await crud.create_user(
-        session, schemas.UserCreate(email="g@e.com", password="Pwd123$")
+        session, schemas.UserCreate(email="g@e.com", password="ComplexPass123$")
     )
     category = await crud.create_category(
         session, schemas.CategoryCreate(name="Food"), user.account_id, user.id


### PR DESCRIPTION
## Summary
- add Transaction model and validator tests
- update ledger service unit tests for new API
- use complex passwords in auth and ledger tests

## Testing
- `pytest -q`
- `pytest --cov=backend -q`

------
https://chatgpt.com/codex/tasks/task_e_6869820c6534832da52dee0e3c4f35aa