### PR TITLE
Handle posted_at timezone

### DIFF
--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -13,7 +13,9 @@ class Transaction(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"))
     category_id = Column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True)
-    posted_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    posted_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     payee = Column(String, nullable=True)
     note = Column(String, nullable=True)
     external_id = Column(String, nullable=True)

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -32,9 +32,13 @@ class TransactionCreate(TransactionBase):
 
     @field_validator("posted_at", mode="before")
     def _parse_posted_at(cls, v):
-        if v is None or isinstance(v, datetime):
+        if v is None:
             return v
-        return datetime.fromisoformat(str(v))
+        if not isinstance(v, datetime):
+            v = datetime.fromisoformat(str(v))
+        if v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
+        return v.astimezone(timezone.utc)
 
 
 class TransactionUpdate(BaseModel):

--- a/backend/app/services/ledger.py
+++ b/backend/app/services/ledger.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import AsyncGenerator
 from uuid import UUID
 
@@ -35,9 +35,11 @@ async def post_entry(
         }
         posted = tx_data.get("posted_at")
         if posted is None:
-            posted = datetime.now().replace(tzinfo=None)
-        elif posted.tzinfo is not None:
-            posted = posted.replace(tzinfo=None)
+            posted = datetime.now(timezone.utc)
+        elif posted.tzinfo is None:
+            posted = posted.replace(tzinfo=timezone.utc)
+        else:
+            posted = posted.astimezone(timezone.utc)
         tx_data["posted_at"] = posted
         tx_obj = models.Transaction(**tx_data, user_id=user_id)
         db.add(tx_obj)

--- a/backend/tests/test_grpc_ledger.py
+++ b/backend/tests/test_grpc_ledger.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 import uuid
+from datetime import timezone
 
 import pytest
 from sqlalchemy import text
@@ -150,3 +151,4 @@ async def test_grpc_post_entry_and_stream():
         ):
             txns.append(item)
         assert len(txns) == 1
+        assert txns[0].posted_at.ToDatetime(tzinfo=timezone.utc).tzinfo == timezone.utc

--- a/tests/grpc/test_ledger_grpc.py
+++ b/tests/grpc/test_ledger_grpc.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+from datetime import timezone
 import pytest
 from grpclib.testing import ChannelFor
 
@@ -61,3 +62,4 @@ async def test_grpc_post_entry(session, monkeypatch):
         )
         assert len(txns) == 1
         assert txns[0].id == resp.id
+        assert txns[0].posted_at.ToDatetime(tzinfo=timezone.utc).tzinfo == timezone.utc

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -16,7 +16,7 @@ def test_transaction_posted_at_tz():
         user_id=uuid4(),
         posted_at=datetime.now(timezone.utc),
     )
-    assert tx.posted_at.tzinfo is not None
+    assert tx.posted_at.tzinfo == timezone.utc
 
 
 def test_transaction_create_validators():
@@ -26,6 +26,7 @@ def test_transaction_create_validators():
         category_id=str(cat_id),
     )
     assert isinstance(tx.posted_at, datetime)
+    assert tx.posted_at.tzinfo == timezone.utc
     assert tx.category_id == cat_id
 
 
@@ -38,3 +39,4 @@ def test_transaction_from_orm():
     data = schemas.Transaction.model_validate(obj)
     assert data.id == obj.id
     assert data.posted_at == obj.posted_at
+    assert data.posted_at.tzinfo == timezone.utc

--- a/tests/unit/test_services_ledger.py
+++ b/tests/unit/test_services_ledger.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import timezone
 from fastapi import HTTPException
 
 from backend.app import schemas, crud
@@ -32,7 +33,7 @@ async def test_post_entry_and_balance(session):
     ]
     async with async_session() as db:
         tx = await ledger.post_entry(db, txn, postings, user.account_id, user.id)
-        assert tx.posted_at.tzinfo is None
+        assert tx.posted_at.tzinfo == timezone.utc
 
         balance = await ledger.get_balance(db, user.account_id)
         assert balance == 100


### PR DESCRIPTION
## Summary
- store `Transaction.posted_at` with timezone info
- keep UTC when posting entries
- parse posted_at as UTC in Pydantic schema
- adjust unit and gRPC tests to expect UTC datetimes

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6869913b3c6c832d962c996c706bbc4d