### PR TITLE
Use Decimal for amounts

### DIFF
--- a/backend/app/grpc/server.py
+++ b/backend/app/grpc/server.py
@@ -66,7 +66,7 @@ class LedgerService(ledger_grpc.LedgerServiceBase):
                 UUID(request.account_id),
                 _ts_to_dt(request.at),
             )
-        await stream.send_message(ledger_pb2.BalanceResponse(amount=amount))
+        await stream.send_message(ledger_pb2.BalanceResponse(amount=float(amount)))
 
     async def StreamTxns(self, stream) -> None:
         request = await stream.recv_message()

--- a/backend/app/schemas/category.py
+++ b/backend/app/schemas/category.py
@@ -1,13 +1,19 @@
 from uuid import UUID
-from pydantic import BaseModel, ConfigDict, field_validator
+from decimal import Decimal
+from pydantic import BaseModel, ConfigDict, field_validator, condecimal
 
-STRICT = ConfigDict(strict=True)
-ORM_STRICT = ConfigDict(from_attributes=True, strict=True)
+STRICT = ConfigDict(strict=True, json_encoders={Decimal: lambda v: float(v)})
+ORM_STRICT = ConfigDict(
+    from_attributes=True, strict=True, json_encoders={Decimal: lambda v: float(v)}
+)
+
+
+Amount = condecimal(max_digits=20, decimal_places=6, strict=False)
 
 
 class CategoryBase(BaseModel):
     name: str
-    monthly_limit: float | None = None
+    monthly_limit: Amount | None = None
     icon: str | None = None
     parent_id: UUID | None = None
 
@@ -26,7 +32,7 @@ class CategoryCreate(CategoryBase):
 
 class CategoryUpdate(BaseModel):
     name: str | None = None
-    monthly_limit: float | None = None
+    monthly_limit: Amount | None = None
     icon: str | None = None
     parent_id: UUID | None = None
 

--- a/backend/app/schemas/posting.py
+++ b/backend/app/schemas/posting.py
@@ -1,12 +1,18 @@
 from uuid import UUID
-from pydantic import BaseModel, ConfigDict, field_validator
+from decimal import Decimal
+from pydantic import BaseModel, ConfigDict, field_validator, condecimal
 
-STRICT = ConfigDict(strict=True)
-ORM_STRICT = ConfigDict(from_attributes=True, strict=True)
+STRICT = ConfigDict(strict=True, json_encoders={Decimal: lambda v: float(v)})
+ORM_STRICT = ConfigDict(
+    from_attributes=True, strict=True, json_encoders={Decimal: lambda v: float(v)}
+)
+
+
+Amount = condecimal(max_digits=20, decimal_places=6, strict=False)
 
 
 class PostingBase(BaseModel):
-    amount: float
+    amount: Amount
     side: str
     account_id: UUID
     currency_code: str | None = None

--- a/backend/app/services/ledger.py
+++ b/backend/app/services/ledger.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 import contextlib
 from sqlalchemy import select, func, case
+from decimal import Decimal
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import HTTPException, status
 
@@ -66,7 +67,7 @@ async def get_balance(
     db: AsyncSession,
     account_id: UUID,
     at: datetime | None = None,
-) -> float:
+) -> Decimal:
     """Return account balance at moment `at`."""
     stmt = (
         select(
@@ -89,7 +90,8 @@ async def get_balance(
     if at:
         stmt = stmt.where(models.Transaction.posted_at <= at)
     result = await db.execute(stmt)
-    return float(result.scalar() or 0)
+    value = result.scalar()
+    return Decimal(value) if value is not None else Decimal("0")
 
 
 async def stream_transactions(


### PR DESCRIPTION
## Summary
- switch amount fields from `float` to constrained `Decimal`
- return Decimal from ledger balance queries
- adapt gRPC layer to send float balances

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68699409533c832d9896e6d876803889