### PR TITLE
Update transaction limit default

### DIFF
--- a/backend/app/api/v1/transactions.py
+++ b/backend/app/api/v1/transactions.py
@@ -34,7 +34,7 @@ async def read_transactions(
     date_from: datetime | None = Query(None, description="Start date (posted_at)"),
     date_to: datetime | None = Query(None, description="End date (posted_at)"),
     category_id: str | None = Query(None, description="Category"),
-    limit: int | None = Query(None, description="Limit"),
+    limit: int = Query(50, description="Limit"),
     session: AsyncSession = Depends(database.get_session),
     current_user: User = Depends(get_current_user),
 ):


### PR DESCRIPTION
## Summary
- set default limit for transactions endpoint

## Testing
- `pytest -q` *(fails: test_post_entry_and_balance)*

------
https://chatgpt.com/codex/tasks/task_e_6869986b6464832d930b20e9866df5d1