### PR TITLE
Fix lint issue in tests

### DIFF
--- a/backend/scripts/load_currencies.py
+++ b/backend/scripts/load_currencies.py
@@ -4,14 +4,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.app import crud, database, schemas
 
 BASE_CURRENCIES = [
-    schemas.CurrencyCreate(code="RUB", name="Российский рубль", symbol="₽", precision=2),
+    schemas.CurrencyCreate(
+        code="RUB", name="Российский рубль", symbol="₽", precision=2
+    ),
     schemas.CurrencyCreate(code="USD", name="Доллар США", symbol="$", precision=2),
     schemas.CurrencyCreate(code="EUR", name="Евро", symbol="€", precision=2),
     schemas.CurrencyCreate(code="GBP", name="Британский фунт", symbol="£", precision=2),
     schemas.CurrencyCreate(code="JPY", name="Иена", symbol="¥", precision=0),
     schemas.CurrencyCreate(code="CNY", name="Китайский юань", symbol="¥", precision=2),
-    schemas.CurrencyCreate(code="CHF", name="Швейцарский франк", symbol="CHF", precision=2),
-    schemas.CurrencyCreate(code="KZT", name="Казахстанский тенге", symbol="₸", precision=2),
+    schemas.CurrencyCreate(
+        code="CHF", name="Швейцарский франк", symbol="CHF", precision=2
+    ),
+    schemas.CurrencyCreate(
+        code="KZT", name="Казахстанский тенге", symbol="₸", precision=2
+    ),
 ]
 
 

--- a/tests/api/test_currency.py
+++ b/tests/api/test_currency.py
@@ -13,8 +13,8 @@ os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test.db"
 
 from backend.app.main import app  # noqa: E402
 from backend.app import currency, database  # noqa: E402
-from backend.scripts.load_currencies import load_currencies
-import asyncio
+from backend.scripts.load_currencies import load_currencies  # noqa: E402
+import asyncio  # noqa: E402
 
 
 async def fake_get_rate(code: str) -> float:


### PR DESCRIPTION
## Summary
- silence E402 import warnings in currency tests
- format load_currencies for black compliance

## Testing
- `make lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869b192e0ec832db681dc995f9f47de