### PR TITLE
Add account filter to transactions list

### DIFF
--- a/backend/app/api/v1/transactions.py
+++ b/backend/app/api/v1/transactions.py
@@ -34,6 +34,7 @@ async def read_transactions(
     date_from: datetime | None = Query(None, description="Start date (posted_at)"),
     date_to: datetime | None = Query(None, description="End date (posted_at)"),
     category_id: str | None = Query(None, description="Category"),
+    account_id: UUID | None = Query(None, description="Account"),
     limit: int = Query(50, description="Limit"),
     session: AsyncSession = Depends(database.get_session),
     current_user: User = Depends(get_current_user),
@@ -41,7 +42,7 @@ async def read_transactions(
     """Вернуть список операций с указанными фильтрами."""
     return await crud.get_transactions(
         session,
-        current_user.account_id,
+        account_id or current_user.account_id,
         date_from=date_from,
         date_to=date_to,
         category_id=category_id,

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -265,17 +265,15 @@ async def delete_category(
 
 async def get_transactions(
     db: AsyncSession,
-    account_id: uuid.UUID,
+    account_id: uuid.UUID | None = None,
     date_from: datetime | None = None,
     date_to: datetime | None = None,
     category_id: uuid.UUID | None = None,
     limit: int | None = None,
 ):
-    stmt = (
-        select(models.Transaction)
-        .join(models.Posting)
-        .where(models.Posting.account_id == account_id)
-    )
+    stmt = select(models.Transaction)
+    if account_id is not None:
+        stmt = stmt.join(models.Posting).where(models.Posting.account_id == account_id)
     if date_from:
         stmt = stmt.where(models.Transaction.posted_at >= date_from)
     if date_to:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -182,6 +182,17 @@ paths:
           description: Category
           title: Category Id
         description: Category
+      - name: account_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          description: Account
+          title: Account Id
+        description: Account
       - name: limit
         in: query
         required: false


### PR DESCRIPTION
## Summary
- allow filtering transactions by `account_id`
- update CRUD to support optional `account_id`
- test filtering behaviour
- regenerate OpenAPI schema

## Testing
- `pre-commit run --files backend/app/api/v1/transactions.py backend/app/crud.py tests/api/test_transactions.py docs/api/openapi.yaml` *(with heavy hooks skipped)*
- `pytest -q tests/api/test_transactions.py`


------
https://chatgpt.com/codex/tasks/task_e_6869b40e4ff4832da1f7005e04728cf2