### PR TITLE
Fix make test to use root tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint:
 	mypy backend/app
 
 test:
-	pytest backend/tests
+	pytest --cov=backend --cov-fail-under=90 tests
 
 ci: lint test
 


### PR DESCRIPTION
## Summary
- run all tests via `pytest --cov=backend --cov-fail-under=90 tests`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869b9832248832d9b5573fe330ab5bd