### PR TITLE
Remove auto schema creation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,7 +21,7 @@ from .api.v1 import (
     users as users_v1,
     currencies as currencies_v1,
 )
-from .database import engine, Base
+from .database import engine
 from .kafka_producer import close as close_producer
 from contextlib import asynccontextmanager
 
@@ -48,8 +48,11 @@ tags_metadata = [
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup and shutdown events using lifespan."""
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    async with engine.begin() as _conn:
+        # База данных инициализируется миграциями Alembic. Таблицы не
+        # создаются автоматически при запуске приложения.
+        # await conn.run_sync(Base.metadata.create_all)
+        pass
     try:
         Instrumentator().instrument(app).expose(app)
     except RuntimeError:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -9,6 +9,12 @@ pip install -r requirements.txt
 uvicorn backend.app.main:app --reload
 ```
 
+Перед запуском приложения выполните миграции базы данных:
+
+```bash
+alembic upgrade head
+```
+
 Переменные окружения:
 - `DATABASE_URL` — строка подключения к PostgreSQL (по умолчанию SQLite);
 - `SECRET_KEY` — ключ для подписи JWT;


### PR DESCRIPTION
## Summary
- disable automatic DB table creation in app startup
- mention running Alembic migrations before launching the API server

## Testing
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_6869bc7f4254832db8fe6c033d0b3762