### PR TITLE
Fix lint by formatting alembic migration

### DIFF
--- a/alembic/versions/dda846dd5702_initial.py
+++ b/alembic/versions/dda846dd5702_initial.py
@@ -1,7 +1,7 @@
 """Initial schema with timescaledb and postings balance trigger
 
 Revision ID: dda846dd5702
-Revises: 
+Revises:
 Create Date: 2025-07-06 00:16:51.171807
 
 """


### PR DESCRIPTION
## Summary
- remove trailing space in alembic migration to satisfy `black`

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6869c3cb8338832d8c75d1149385afb9