### PR TITLE
Add password validation on user creation

### DIFF
--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -41,6 +41,10 @@ async def create_user(
     user: schemas.UserCreate, session: AsyncSession = Depends(database.get_session)
 ):
     """Зарегистрировать нового пользователя."""
+    try:
+        security.validate_password(user.password)
+    except ValueError as exc:
+        raise api_error(400, str(exc), "INVALID_PASSWORD") from exc
     db_user = await crud.get_user_by_email(session, user.email)
     if db_user:
         raise api_error(400, "Email already registered", "EMAIL_EXISTS")

--- a/tests/api/test_analytics.py
+++ b/tests/api/test_analytics.py
@@ -13,7 +13,7 @@ os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test.db"
 from backend.app.main import app  # noqa: E402
 
 
-def _login(client, email="ana@example.com", password="pass"):
+def _login(client, email="ana@example.com", password="ComplexPass123$"):
     user = {"email": email, "password": password}
     r = client.post("/users/", json=user)
     assert r.status_code == 200

--- a/tests/api/test_banks.py
+++ b/tests/api/test_banks.py
@@ -16,7 +16,7 @@ from backend.app import schemas, vault  # noqa: E402
 
 
 def _login(client):
-    user = {"email": "bank@example.com", "password": "pass"}
+    user = {"email": "bank@example.com", "password": "ComplexPass123$"}
     r = client.post("/users/", json=user)
     assert r.status_code == 200
     r = client.post(

--- a/tests/api/test_categories.py
+++ b/tests/api/test_categories.py
@@ -15,7 +15,7 @@ from backend.app.main import app  # noqa: E402
 
 
 def _create_user(client):
-    user = {"email": "cat@example.com", "password": "pass"}
+    user = {"email": "cat@example.com", "password": "ComplexPass123$"}
     r = client.post("/users/", json=user)
     assert r.status_code == 200
     assert r.json()["role"] == "owner"
@@ -71,7 +71,7 @@ def test_category_crud():
 
 def test_subcategory_creation():
     with TestClient(app) as client:
-        user = {"email": "cat2@example.com", "password": "pass"}
+        user = {"email": "cat2@example.com", "password": "ComplexPass123$"}
         r = client.post("/users/", json=user)
         assert r.status_code == 200
         token = _login(client, user)

--- a/tests/api/test_goals.py
+++ b/tests/api/test_goals.py
@@ -14,7 +14,7 @@ from backend.app.main import app  # noqa: E402
 
 
 def _login(client):
-    user = {"email": "goal@example.com", "password": "pass"}
+    user = {"email": "goal@example.com", "password": "ComplexPass123$"}
     r = client.post("/users/", json=user)
     assert r.status_code == 200
     r = client.post(

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -16,7 +16,7 @@ from backend.app import tasks  # noqa: E402
 
 
 def _login(client, email="job@example.com"):
-    user = {"email": email, "password": "pass"}
+    user = {"email": email, "password": "ComplexPass123$"}
     r = client.post("/users/", json=user)
     assert r.status_code == 200
     r = client.post(

--- a/tests/api/test_notifications.py
+++ b/tests/api/test_notifications.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def _login(client):
-    user = {"email": "notif@example.com", "password": "pass"}
+    user = {"email": "notif@example.com", "password": "ComplexPass123$"}
     r = client.post("/users/", json=user)
     assert r.status_code == 200
     r = client.post(

--- a/tests/api/test_push.py
+++ b/tests/api/test_push.py
@@ -14,7 +14,7 @@ from backend.app.main import app  # noqa: E402
 
 
 def _login(client):
-    user = {"email": "push@example.com", "password": "pass"}
+    user = {"email": "push@example.com", "password": "ComplexPass123$"}
     r = client.post("/users/", json=user)
     assert r.status_code == 200
     r = client.post(

--- a/tests/api/test_recurring.py
+++ b/tests/api/test_recurring.py
@@ -13,7 +13,7 @@ os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test.db"
 from backend.app.main import app  # noqa: E402
 
 
-def _login(client, email="test@example.com", password="pass"):
+def _login(client, email="test@example.com", password="ComplexPass123$"):
     user = {"email": email, "password": password}
     r = client.post("/users/", json=user)
     assert r.status_code == 200

--- a/tests/api/test_tokens.py
+++ b/tests/api/test_tokens.py
@@ -15,7 +15,7 @@ from backend.app import vault  # noqa: E402
 
 
 def _login(client):
-    user = {"email": "tok@example.com", "password": "pass"}
+    user = {"email": "tok@example.com", "password": "ComplexPass123$"}
     r = client.post("/users/", json=user)
     assert r.status_code == 200
     r = client.post(

--- a/tests/api/test_transactions.py
+++ b/tests/api/test_transactions.py
@@ -16,7 +16,7 @@ from backend.app.main import app  # noqa: E402
 
 
 def _login(client, email="tx@example.com"):
-    user = {"email": email, "password": "pass"}
+    user = {"email": email, "password": "ComplexPass123$"}
     r = client.post("/users/", json=user)
     assert r.status_code == 200
     r = client.post(

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -15,7 +15,7 @@ from backend.app.main import app  # noqa: E402
 
 def test_create_and_login_user():
     with TestClient(app) as client:
-        user = {"email": "u@example.com", "password": "pass"}
+        user = {"email": "u@example.com", "password": "ComplexPass123$"}
         r = client.post("/users/", json=user)
         assert r.status_code == 200
         data = r.json()
@@ -35,7 +35,7 @@ def test_create_and_login_user():
 def test_join_account():
     with TestClient(app) as client:
         # create first user (owner of account)
-        owner = {"email": "owner@example.com", "password": "pass"}
+        owner = {"email": "owner@example.com", "password": "ComplexPass123$"}
         r = client.post("/users/", json=owner)
         assert r.status_code == 200
         owner_data = r.json()
@@ -46,7 +46,7 @@ def test_join_account():
         )
 
         # create second user
-        member = {"email": "member@example.com", "password": "pass"}
+        member = {"email": "member@example.com", "password": "ComplexPass123$"}
         r = client.post("/users/", json=member)
         assert r.status_code == 200
         member_token = client.post(
@@ -70,7 +70,7 @@ def test_join_account():
 
 def test_members_list_and_remove():
     with TestClient(app) as client:
-        owner = {"email": "own2@example.com", "password": "pass"}
+        owner = {"email": "own2@example.com", "password": "ComplexPass123$"}
         r = client.post("/users/", json=owner)
         assert r.status_code == 200
         owner_data = r.json()
@@ -81,7 +81,7 @@ def test_members_list_and_remove():
         ).json()["access_token"]
         headers_owner = {"Authorization": f"Bearer {owner_token}"}
 
-        member = {"email": "mem2@example.com", "password": "pass"}
+        member = {"email": "mem2@example.com", "password": "ComplexPass123$"}
         r = client.post("/users/", json=member)
         assert r.status_code == 200
         member_token = client.post(
@@ -113,7 +113,7 @@ def test_members_list_and_remove():
 
 def test_update_user_profile():
     with TestClient(app) as client:
-        user = {"email": "prof@example.com", "password": "pass"}
+        user = {"email": "prof@example.com", "password": "ComplexPass123$"}
         r = client.post("/users/", json=user)
         assert r.status_code == 200
 


### PR DESCRIPTION
## Summary
- validate password in `POST /users/` handler before creating user
- update API tests to use valid passwords

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869c642ed5c832d9b75abcdf554822b