### PR TITLE
Fix lint errors due to unused imports

### DIFF
--- a/tests/grpc/test_grpc_ledger.py
+++ b/tests/grpc/test_grpc_ledger.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from pathlib import Path
-import uuid
 from datetime import timezone
 
 import pytest

--- a/tests/unit/test_ledger.py
+++ b/tests/unit/test_ledger.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from pathlib import Path
-import uuid
 import pytest
 from sqlalchemy import select, func, text
 import pytest_asyncio


### PR DESCRIPTION
## Summary
- remove unused `uuid` imports from tests

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869ce6928bc832d9842c7fcb3891dc4