### PR TITLE
Make database echo configurable

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -8,8 +8,11 @@ import os
 # строка подключения берется из переменной окружения
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./app.db")
 
+# если переменная окружения DB_ECHO установлена в true/1/yes, включаем логгирование SQL
+DB_ECHO = os.getenv("DB_ECHO", "0").lower() in {"1", "true", "yes"}
+
 # создаём движок и фабрику сессий
-engine = create_async_engine(DATABASE_URL, echo=True)
+engine = create_async_engine(DATABASE_URL, echo=DB_ECHO)
 async_session = async_sessionmaker(engine, expire_on_commit=False)
 
 


### PR DESCRIPTION
## Summary
- make SQLAlchemy engine's echo configurable via `DB_ECHO` environment variable

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686aafe20e84832dac7beac412c09ee5