### PR TITLE
Add bank-bridge service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,5 +64,18 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  bank-bridge:
+    build:
+      context: .
+      dockerfile: services/bank_bridge/Dockerfile
+    env_file: .env
+    ports:
+      - "8080:8080"
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512m
 volumes:
   db_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,6 @@ grpcio==1.73.1
 grpcio-tools==1.73.1
 protobuf>=6.31
 PyYAML
+
+aiohttp
+asyncio-jobs

--- a/services/bank_bridge/Dockerfile
+++ b/services/bank_bridge/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "services.bank_bridge.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/bank_bridge/app.py
+++ b/services/bank_bridge/app.py
@@ -1,0 +1,56 @@
+from typing import Any
+
+import aiohttp
+from fastapi import FastAPI
+from asyncio_jobs import Job, JobScheduler
+
+app = FastAPI(title="Bank Bridge")
+
+scheduler: JobScheduler | None = None
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    global scheduler
+    scheduler = JobScheduler()
+    scheduler.start()
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    if scheduler:
+        await scheduler.close()
+
+
+@app.get("/healthz")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+async def external_request(method: str, url: str, **kwargs: Any) -> Any:
+    async with aiohttp.ClientSession() as session:
+        async with session.request(method, url, **kwargs) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+
+@app.post("/connect/{bank}")
+async def connect(bank: str) -> dict[str, str]:
+    job = Job(coro=external_request("POST", f"https://api.example.com/{bank}/connect"))
+    assert scheduler
+    scheduler.spawn(job)
+    return {"status": "connecting"}
+
+
+@app.get("/status/{bank}")
+async def status(bank: str) -> dict[str, Any]:
+    data = await external_request("GET", f"https://api.example.com/{bank}/status")
+    return {"status": data}
+
+
+@app.post("/sync/{bank}")
+async def sync(bank: str) -> dict[str, str]:
+    job = Job(coro=external_request("POST", f"https://api.example.com/{bank}/sync"))
+    assert scheduler
+    scheduler.spawn(job)
+    return {"status": "scheduled"}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -8,6 +8,10 @@ build:
       context: .
       docker:
         dockerfile: backend/Dockerfile
+    - image: bank-bridge
+      context: .
+      docker:
+        dockerfile: services/bank_bridge/Dockerfile
 
 deploy:
   helm:
@@ -28,3 +32,7 @@ portForward:
     resourceName: budget-machine-budget-machine
     port: 80
     localPort: 8000
+  - resourceType: Service
+    resourceName: bank-bridge-bank-bridge
+    port: 8080
+    localPort: 8080


### PR DESCRIPTION
## Summary
- add Bank Bridge FastAPI service using aiohttp and asyncio-jobs
- include Dockerfile for bank-bridge
- expose new bank-bridge container in docker-compose and skaffold
- add aiohttp and asyncio-jobs dependencies

## Testing
- `pre-commit run --files services/bank_bridge/app.py services/bank_bridge/Dockerfile docker-compose.yml skaffold.yaml requirements.txt` *(fails: terrascan command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab6dc6730832db2bfe37456b1d378