### PR TITLE
Fix missing asyncio-jobs dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ protobuf>=6.31
 PyYAML
 
 aiohttp
-asyncio-jobs
+aiojobs


### PR DESCRIPTION
## Summary
- replace nonexistent `asyncio-jobs` with `aiojobs`
- update bank bridge service to use `aiojobs`

## Testing
- `pip install --disable-pip-version-check -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_686abf0a8870832db363e3eaf484befc