### PR TITLE
Add Kafka utils and bank schemas

### DIFF
--- a/schemas/bank-bridge/bank.err/1.0.0/schema.json
+++ b/schemas/bank-bridge/bank.err/1.0.0/schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "bank.err",
+  "type": "object",
+  "properties": {
+    "user_id": {"type": "string", "format": "uuid"},
+    "bank_txn_id": {"type": "string"},
+    "error": {"type": "string"},
+    "data": {"type": "object"}
+  },
+  "required": ["user_id", "bank_txn_id", "error"]
+}

--- a/schemas/bank-bridge/bank.norm/1.0.0/schema.json
+++ b/schemas/bank-bridge/bank.norm/1.0.0/schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "bank.norm",
+  "type": "object",
+  "properties": {
+    "user_id": {"type": "string", "format": "uuid"},
+    "bank_txn_id": {"type": "string"},
+    "transaction": {"type": "object"}
+  },
+  "required": ["user_id", "bank_txn_id", "transaction"]
+}

--- a/schemas/bank-bridge/bank.raw/1.0.0/schema.json
+++ b/schemas/bank-bridge/bank.raw/1.0.0/schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "bank.raw",
+  "type": "object",
+  "properties": {
+    "user_id": {"type": "string", "format": "uuid"},
+    "bank_txn_id": {"type": "string"},
+    "payload": {"type": "object"}
+  },
+  "required": ["user_id", "bank_txn_id", "payload"]
+}

--- a/services/bank_bridge/kafka.py
+++ b/services/bank_bridge/kafka.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from aiokafka import AIOKafkaProducer
+
+KAFKA_BROKER_URL = os.getenv("KAFKA_BROKER_URL", "localhost:9092")
+TRANSACTIONAL_ID = os.getenv("KAFKA_TRANSACTIONAL_ID", "bank-bridge")
+
+_producer: AIOKafkaProducer | None = None
+
+
+async def get_producer() -> AIOKafkaProducer:
+    """Return a global Kafka producer with exactly-once guarantees."""
+    global _producer
+    if _producer is None:
+        _producer = AIOKafkaProducer(
+            bootstrap_servers=KAFKA_BROKER_URL,
+            enable_idempotence=True,
+            transactional_id=TRANSACTIONAL_ID,
+        )
+        await _producer.start()
+        await _producer.init_transactions()
+    return _producer
+
+
+async def publish(
+    topic: str, user_id: str, bank_txn_id: str, data: dict[str, Any]
+) -> None:
+    """Send data to Kafka using `user_id:bank_txn_id` as key."""
+    producer = await get_producer()
+    key = f"{user_id}:{bank_txn_id}".encode()
+    payload = json.dumps(data).encode()
+
+    await producer.begin_transaction()
+    try:
+        await producer.send_and_wait(topic, payload, key=key)
+        await producer.commit_transaction()
+    except Exception:  # pragma: no cover - network operations
+        await producer.abort_transaction()
+        raise
+
+
+async def close() -> None:
+    """Stop the producer if it was started."""
+    global _producer
+    if _producer is not None:
+        await _producer.stop()
+        _producer = None

--- a/services/bank_bridge/normalizer.py
+++ b/services/bank_bridge/normalizer.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from backend.app.schemas.transaction import TransactionCreate
+from backend.app.schemas.posting import PostingCreate
+
+from . import kafka
+
+
+def normalize_record(raw: dict[str, Any]) -> TransactionCreate:
+    """Convert raw bank transaction to :class:`TransactionCreate`."""
+    amount = float(raw["amount"])
+    return TransactionCreate(
+        posted_at=datetime.fromisoformat(raw["date"]),
+        payee=raw.get("payee"),
+        note=raw.get("description"),
+        external_id=str(raw.get("bank_txn_id")),
+        postings=[
+            PostingCreate(
+                amount=abs(amount),
+                side="credit" if amount > 0 else "debit",
+                account_id=UUID(str(raw["account_id"])),
+                currency_code=raw.get("currency", "RUB"),
+            )
+        ],
+    )
+
+
+async def process(raw: dict[str, Any]) -> None:
+    """Normalize raw data and publish to Kafka."""
+    user_id = str(raw.get("user_id"))
+    bank_txn_id = str(raw.get("bank_txn_id"))
+    try:
+        tx = normalize_record(raw)
+    except Exception as exc:  # pragma: no cover - simple error path
+        await kafka.publish(
+            "bank.err",
+            user_id,
+            bank_txn_id,
+            {"error": str(exc), "data": raw},
+        )
+        return
+
+    await kafka.publish(
+        "bank.norm",
+        user_id,
+        bank_txn_id,
+        tx.model_dump(mode="json", exclude_none=True),
+    )


### PR DESCRIPTION
## Summary
- add a Kafka helper with exactly-once semantics for bank_bridge
- implement normalizer module that publishes to `bank.norm` and `bank.err`
- add JSON schemas for `bank.raw`, `bank.norm` and `bank.err`

## Testing
- `ruff check services/bank_bridge/kafka.py services/bank_bridge/normalizer.py`
- `black services/bank_bridge/kafka.py services/bank_bridge/normalizer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_686ac9e915e0832da770439bce795008