### PR TITLE
Add bank_bridge tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev ci lint test devcontainer proto openapi demo_user
+.PHONY: dev ci lint test devcontainer proto openapi demo_user bankbridge-tests
 
 
 dev:
@@ -26,3 +26,6 @@ openapi:
 
 demo_user:
 	python -m backend.scripts.create_demo_user
+
+bankbridge-tests:
+	pytest tests/bank_bridge

--- a/tests/bank_bridge/docker-compose.yml
+++ b/tests/bank_bridge/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+services:
+  kafka:
+    image: bitnami/kafka:3
+    environment:
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    ports:
+      - "9092:9092"
+  stub-bank:
+    image: ghcr.io/vintasoftware/stubs-http:latest
+    environment:
+      - PORT=8081
+    volumes:
+      - ./stubs:/stubs:ro
+    command: stubs 0.0.0.0 8081 /stubs
+    ports:
+      - "8081:8081"
+  core-mock:
+    image: ghcr.io/vintasoftware/stubs-http:latest
+    environment:
+      - PORT=8082
+    volumes:
+      - ./core:/stubs:ro
+    command: stubs 0.0.0.0 8082 /stubs
+    ports:
+      - "8082:8082"

--- a/tests/bank_bridge/test_contracts.py
+++ b/tests/bank_bridge/test_contracts.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+schema_dir = Path("schemas/bank-bridge")
+
+
+def load_schemas():
+    for path in schema_dir.rglob("schema.json"):
+        with open(path, "r", encoding="utf-8") as f:
+            yield path.name, json.load(f)
+
+
+def test_json_schemas_valid():
+    for name, schema in load_schemas():
+        Draft202012Validator.check_schema(schema)
+
+
+@pytest.mark.asyncio
+async def test_openapi_contract():
+    schemathesis = pytest.importorskip("schemathesis")
+    from asgi_lifespan import LifespanManager
+    from httpx import AsyncClient, ASGITransport
+
+    try:
+        from backend.app.main import app
+    except ModuleNotFoundError as exc:
+        pytest.skip(str(exc))
+
+    async with LifespanManager(app):
+        schema = schemathesis.from_asgi("/openapi.json", app, base_url="http://test")
+
+        @schema.parametrize()
+        async def run(case):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await case.call_asgi()
+            case.validate_response(response)
+
+        await run()

--- a/tests/bank_bridge/test_normalizer.py
+++ b/tests/bank_bridge/test_normalizer.py
@@ -1,0 +1,176 @@
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from services.bank_bridge import normalizer
+
+
+def test_normalize_record_credit():
+    raw = {
+        "amount": 100,
+        "date": "2024-01-01T12:00:00",
+        "account_id": uuid4(),
+        "bank_txn_id": 1,
+    }
+    tx = normalizer.normalize_record(raw)
+    assert tx.postings[0].side == "credit"
+    assert tx.postings[0].amount == 100
+    assert tx.posted_at == datetime.fromisoformat("2024-01-01T12:00:00+00:00")
+
+
+def test_normalize_record_debit_default_currency():
+    aid = uuid4()
+    raw = {
+        "amount": -50,
+        "date": "2024-01-02T00:00:00",
+        "account_id": aid,
+        "bank_txn_id": 2,
+    }
+    tx = normalizer.normalize_record(raw)
+    p = tx.postings[0]
+    assert p.side == "debit"
+    assert p.currency_code == "RUB"
+    assert p.account_id == aid
+
+
+def test_normalize_record_missing_field():
+    raw = {"amount": 1, "date": "bad", "account_id": uuid4(), "bank_txn_id": 3}
+    with pytest.raises(Exception):
+        normalizer.normalize_record(raw)
+
+
+@pytest.mark.asyncio
+async def test_process_success(monkeypatch):
+    sent = {}
+
+    async def fake_publish(topic, user_id, bank_txn_id, data):
+        sent.update({"topic": topic, "uid": user_id, "bid": bank_txn_id, "data": data})
+
+    monkeypatch.setattr(normalizer.kafka, "publish", fake_publish)
+    raw = {
+        "amount": 10,
+        "date": "2024-01-03T00:00:00",
+        "account_id": uuid4(),
+        "bank_txn_id": 5,
+        "user_id": uuid4(),
+    }
+    await normalizer.process(raw)
+    assert sent["topic"] == "bank.norm"
+    assert sent["uid"] == str(raw["user_id"])
+    assert sent["bid"] == "5"
+    assert sent["data"]["postings"][0]["amount"] == 10
+
+
+@pytest.mark.asyncio
+async def test_process_error(monkeypatch):
+    def bad_norm(raw):
+        raise ValueError("boom")
+
+    sent = {}
+
+    async def fake_publish(topic, user_id, bank_txn_id, data):
+        sent.update({"topic": topic, "data": data})
+
+    monkeypatch.setattr(normalizer, "normalize_record", bad_norm)
+    monkeypatch.setattr(normalizer.kafka, "publish", fake_publish)
+    raw = {"user_id": uuid4(), "bank_txn_id": 9}
+    await normalizer.process(raw)
+    assert sent["topic"] == "bank.err"
+    assert sent["data"]["error"] == "boom"
+
+
+def test_normalize_record_payee_and_note():
+    aid = uuid4()
+    raw = {
+        "amount": 20,
+        "date": "2024-01-04T00:00:00",
+        "account_id": aid,
+        "bank_txn_id": 4,
+        "payee": "Shop",
+        "description": "note",
+    }
+    tx = normalizer.normalize_record(raw)
+    assert tx.payee == "Shop"
+    assert tx.note == "note"
+
+
+@pytest.mark.asyncio
+async def test_process_external_id(monkeypatch):
+    sent = {}
+
+    async def fake_publish(topic, user_id, bank_txn_id, data):
+        sent.update(data)
+
+    monkeypatch.setattr(normalizer.kafka, "publish", fake_publish)
+    raw = {
+        "amount": 5,
+        "date": "2024-01-05T00:00:00",
+        "account_id": uuid4(),
+        "bank_txn_id": 7,
+        "user_id": uuid4(),
+    }
+    await normalizer.process(raw)
+    assert sent["external_id"] == "7"
+
+
+@pytest.mark.asyncio
+async def test_process_error_contains_raw(monkeypatch):
+    def bad_norm(raw):
+        raise ValueError("fail")
+
+    captured = {}
+
+    async def fake_publish(topic, user_id, bank_txn_id, data):
+        captured.update(data)
+
+    monkeypatch.setattr(normalizer, "normalize_record", bad_norm)
+    monkeypatch.setattr(normalizer.kafka, "publish", fake_publish)
+    raw = {"user_id": uuid4(), "bank_txn_id": 8, "foo": "bar"}
+    await normalizer.process(raw)
+    assert captured["data"]["foo"] == "bar"
+
+
+@pytest.mark.asyncio
+async def test_process_called_once(monkeypatch):
+    count = 0
+
+    async def fake_publish(*args, **kwargs):
+        nonlocal count
+        count += 1
+
+    monkeypatch.setattr(normalizer.kafka, "publish", fake_publish)
+    raw = {
+        "amount": 1,
+        "date": "2024-01-06T00:00:00",
+        "account_id": uuid4(),
+        "bank_txn_id": 10,
+        "user_id": uuid4(),
+    }
+    await normalizer.process(raw)
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_process_calls_normalize(monkeypatch):
+    called = False
+
+    def fake_norm(raw):
+        nonlocal called
+        called = True
+        return normalizer.normalize_record(
+            {
+                "amount": 1,
+                "date": "2024-01-07T00:00:00",
+                "account_id": uuid4(),
+                "bank_txn_id": 11,
+            }
+        )
+
+    async def fake_publish(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(normalizer, "normalize_record", fake_norm)
+    monkeypatch.setattr(normalizer.kafka, "publish", fake_publish)
+    await normalizer.process({"user_id": uuid4(), "bank_txn_id": 11})
+    assert called

--- a/tests/bank_bridge/test_tinkoff_connector.py
+++ b/tests/bank_bridge/test_tinkoff_connector.py
@@ -1,0 +1,143 @@
+import os
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+import respx
+from httpx import Response
+
+from services.bank_bridge.connectors.tinkoff import TinkoffConnector
+
+
+@pytest.fixture(autouse=True)
+def env_setup(monkeypatch):
+    monkeypatch.setenv("TINKOFF_CLIENT_ID", "cid")
+    monkeypatch.setenv("TINKOFF_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("TINKOFF_REDIRECT_URI", "https://app/callback")
+
+
+def make_connector(token=None):
+    return TinkoffConnector(user_id="u1", token=token)
+
+
+@pytest.mark.asyncio
+async def test_auth_url(monkeypatch):
+    saved = {}
+
+    async def fake_save(self):
+        saved["token"] = self.token
+
+    monkeypatch.setattr(TinkoffConnector, "_save_token", fake_save, raising=False)
+    c = make_connector(token="tok")
+    url = await c.auth()
+    assert "response_type=code" in url
+    assert "client_id=cid" in url
+    assert saved["token"] == "tok"
+
+
+@pytest.mark.asyncio
+async def test_refresh_no_token():
+    c = make_connector()
+    with pytest.raises(RuntimeError):
+        await c.refresh()
+
+
+@pytest.mark.asyncio
+async def test_refresh_success(monkeypatch):
+    c = make_connector()
+    c.refresh_token = "r1"
+    called = {}
+
+    async def fake_save(self):
+        called["save"] = True
+
+    monkeypatch.setattr(TinkoffConnector, "_save_token", fake_save, raising=False)
+    with respx.mock(assert_all_called=True) as rsx:
+        rsx.post(c.TOKEN_URL).respond(200, json={"access_token": "at", "refresh_token": "r2"})
+        token = await c.refresh()
+    assert token == "at"
+    assert c.token == "at"
+    assert c.refresh_token == "r2"
+    assert called.get("save")
+
+
+@pytest.mark.asyncio
+async def test_fetch_accounts(monkeypatch):
+    c = make_connector(token="at")
+    accounts = [{"id": 1}]
+    with respx.mock(assert_all_called=True) as rsx:
+        rsx.get(c.BASE_URL + "accounts").respond(200, json={"payload": accounts})
+        result = await c.fetch_accounts()
+    assert result == accounts
+
+
+@pytest.mark.asyncio
+async def test_fetch_accounts_refresh(monkeypatch):
+    c = make_connector()
+    c.refresh_token = "r1"
+    async def noop(self):
+        pass
+
+    monkeypatch.setattr(TinkoffConnector, "_save_token", noop, raising=False)
+    with respx.mock(assert_all_called=True) as rsx:
+        rsx.post(c.TOKEN_URL).respond(200, json={"access_token": "at"})
+        rsx.get(c.BASE_URL + "accounts").respond(200, json={"payload": []})
+        await c.fetch_accounts()
+
+
+@pytest.mark.asyncio
+async def test_fetch_txns(monkeypatch):
+    c = make_connector(token="t1")
+    txns = [{"id": 2}]
+    start = datetime(2023, 1, 1)
+    end = datetime(2023, 1, 2)
+    with respx.mock(assert_all_called=True) as rsx:
+        rsx.get(c.BASE_URL + "transactions").respond(200, json={"payload": txns})
+        result = await c.fetch_txns("acc", start, end)
+    assert result == txns
+
+
+@pytest.mark.asyncio
+async def test_fetch_txns_refresh(monkeypatch):
+    c = make_connector()
+    c.refresh_token = "r1"
+    async def noop(self):
+        pass
+
+    monkeypatch.setattr(TinkoffConnector, "_save_token", noop, raising=False)
+    start = datetime(2023, 1, 1)
+    end = datetime(2023, 1, 2)
+    with respx.mock(assert_all_called=True) as rsx:
+        rsx.post(c.TOKEN_URL).respond(200, json={"access_token": "at"})
+        rsx.get(c.BASE_URL + "transactions").respond(200, json={"payload": []})
+        await c.fetch_txns("acc", start, end)
+
+
+@pytest.mark.asyncio
+async def test_refresh_error(monkeypatch):
+    c = make_connector()
+    c.refresh_token = "r1"
+    with respx.mock(assert_all_called=True) as rsx:
+        rsx.post(c.TOKEN_URL).respond(400)
+        with pytest.raises(Exception):
+            await c.refresh()
+
+
+@pytest.mark.asyncio
+async def test_fetch_accounts_error(monkeypatch):
+    c = make_connector(token="at")
+    with respx.mock(assert_all_called=True) as rsx:
+        rsx.get(c.BASE_URL + "accounts").respond(500)
+        with pytest.raises(Exception):
+            await c.fetch_accounts()
+
+
+@pytest.mark.asyncio
+async def test_fetch_txns_error(monkeypatch):
+    c = make_connector(token="at")
+    start = datetime(2023, 1, 1)
+    end = datetime(2023, 1, 2)
+    with respx.mock(assert_all_called=True) as rsx:
+        rsx.get(c.BASE_URL + "transactions").respond(401)
+        with pytest.raises(Exception):
+            await c.fetch_txns("acc", start, end)


### PR DESCRIPTION
## Summary
- add a new test suite for bank_bridge (unit tests, OpenAPI check, schemas)
- provide docker-compose for integration testing
- expose `make bankbridge-tests` target

## Testing
- `make bankbridge-tests`

------
https://chatgpt.com/codex/tasks/task_e_686aebe4a234832da4e83f4846017938