### PR TITLE
Add BankBridge CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,35 @@ jobs:
       - name: Run tests
         run: pytest --cov=backend --cov-fail-under=90 tests
 
+  bankbridge-tests:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r backend/requirements-dev.txt
+          pip install jsonschema respx
+      - name: Start services
+        run: docker-compose -f tests/bank_bridge/docker-compose.yml up -d
+      - name: Run bankbridge tests
+        run: make bankbridge-tests
+      - name: Stop services
+        if: always()
+        run: docker-compose -f tests/bank_bridge/docker-compose.yml down
+      - name: Build bankbridge image
+        run: docker build -t bankbridge:${{ github.sha }} -f services/bank_bridge/Dockerfile .
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@v0.32.0
+        with:
+          image-ref: bankbridge:${{ github.sha }}
+          severity: CRITICAL
+          exit-code: '1'
+
   codeql:
     permissions:
       contents: read

--- a/tests/bank_bridge/test_contracts.py
+++ b/tests/bank_bridge/test_contracts.py
@@ -35,7 +35,7 @@ async def test_openapi_contract():
         @schema.parametrize()
         async def run(case):
             transport = ASGITransport(app=app)
-            async with AsyncClient(transport=transport, base_url="http://test") as client:
+            async with AsyncClient(transport=transport, base_url="http://test"):
                 response = await case.call_asgi()
             case.validate_response(response)
 

--- a/tests/bank_bridge/test_tinkoff_connector.py
+++ b/tests/bank_bridge/test_tinkoff_connector.py
@@ -1,10 +1,7 @@
-import os
 from datetime import datetime
-from uuid import uuid4
 
 import pytest
 import respx
-from httpx import Response
 
 from services.bank_bridge.connectors.tinkoff import TinkoffConnector
 
@@ -53,7 +50,9 @@ async def test_refresh_success(monkeypatch):
 
     monkeypatch.setattr(TinkoffConnector, "_save_token", fake_save, raising=False)
     with respx.mock(assert_all_called=True) as rsx:
-        rsx.post(c.TOKEN_URL).respond(200, json={"access_token": "at", "refresh_token": "r2"})
+        rsx.post(c.TOKEN_URL).respond(
+            200, json={"access_token": "at", "refresh_token": "r2"}
+        )
         token = await c.refresh()
     assert token == "at"
     assert c.token == "at"
@@ -75,6 +74,7 @@ async def test_fetch_accounts(monkeypatch):
 async def test_fetch_accounts_refresh(monkeypatch):
     c = make_connector()
     c.refresh_token = "r1"
+
     async def noop(self):
         pass
 
@@ -101,6 +101,7 @@ async def test_fetch_txns(monkeypatch):
 async def test_fetch_txns_refresh(monkeypatch):
     c = make_connector()
     c.refresh_token = "r1"
+
     async def noop(self):
         pass
 


### PR DESCRIPTION
## Summary
- fix linter warnings in BankBridge tests
- run BankBridge tests in CI using docker-compose
- build `bankbridge` image and scan with Trivy

## Testing
- `make lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686af0cf3e64832dbe22161b716f4cfe