### PR TITLE
Fix test dependency imports

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -6,3 +6,5 @@ pytest-asyncio
 pytest-cov
 asgi_lifespan
 commitizen
+jsonschema
+respx<0.22


### PR DESCRIPTION
## Summary
- add missing test requirements for bank-bridge tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af4028874832da85d6df8c5477b79