### PR TITLE
Fix Trivy action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build bankbridge image
         run: docker build -t bankbridge:${{ github.sha }} -f services/bank_bridge/Dockerfile .
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@v0.32.0
+        uses: aquasecurity/trivy-action@0.32.0
         with:
           image-ref: bankbridge:${{ github.sha }}
           severity: CRITICAL


### PR DESCRIPTION
## Summary
- fix wrong Trivy action tag in CI workflow

## Testing
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_686af6ffffa0832d87cd26f91bc9f80f