### PR TITLE
Refactor bank bridge connector interfaces

### DIFF
--- a/services/bank_bridge/connectors/gazprom.py
+++ b/services/bank_bridge/connectors/gazprom.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any
+from datetime import date, datetime
+from typing import Any, AsyncGenerator
 
-from .base import BaseConnector
+from .base import Account, BaseConnector, RawTxn, TokenPair
 
 
 class GazpromConnector(BaseConnector):
@@ -12,21 +12,28 @@ class GazpromConnector(BaseConnector):
     name = "gazprom"
     display = "Газпромбанк"
 
-    def __init__(self, user_id: str, token: str | None = None) -> None:
+    def __init__(self, user_id: str, token: TokenPair | None = None) -> None:
         super().__init__(user_id, token)
 
-    async def auth(self) -> str:
-        await self._save_token()
-        return "https://example.com/gazprom/auth"
+    async def auth(self, code: str | None, **kwargs: Any) -> TokenPair:
+        token = TokenPair(access_token="https://example.com/gazprom/auth")
+        await self._save_token(token)
+        return token
 
-    async def refresh(self) -> str:
-        await self._save_token()
-        return ""
+    async def refresh(self, token: TokenPair) -> TokenPair:
+        await self._save_token(token)
+        return token
 
-    async def fetch_accounts(self) -> list[dict[str, Any]]:
+    async def fetch_accounts(self, token: TokenPair) -> list[Account]:
         return []
 
     async def fetch_txns(
-        self, account_id: str, start: datetime, end: datetime
-    ) -> list[dict[str, Any]]:
-        return []
+        self,
+        token: TokenPair,
+        account: Account,
+        date_from: date,
+        date_to: date,
+    ) -> AsyncGenerator[RawTxn, None]:
+        if False:
+            yield
+        return

--- a/services/bank_bridge/connectors/sber.py
+++ b/services/bank_bridge/connectors/sber.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any
+from datetime import date, datetime
+from typing import Any, AsyncGenerator
 
-from .base import BaseConnector
+from .base import Account, BaseConnector, RawTxn, TokenPair
 
 
 class SberConnector(BaseConnector):
@@ -12,21 +12,28 @@ class SberConnector(BaseConnector):
     name = "sber"
     display = "Сбербанк"
 
-    def __init__(self, user_id: str, token: str | None = None) -> None:
+    def __init__(self, user_id: str, token: TokenPair | None = None) -> None:
         super().__init__(user_id, token)
 
-    async def auth(self) -> str:
-        await self._save_token()
-        return "https://example.com/sber/auth"
+    async def auth(self, code: str | None, **kwargs: Any) -> TokenPair:
+        token = TokenPair(access_token="https://example.com/sber/auth")
+        await self._save_token(token)
+        return token
 
-    async def refresh(self) -> str:
-        await self._save_token()
-        return ""
+    async def refresh(self, token: TokenPair) -> TokenPair:
+        await self._save_token(token)
+        return token
 
-    async def fetch_accounts(self) -> list[dict[str, Any]]:
+    async def fetch_accounts(self, token: TokenPair) -> list[Account]:
         return []
 
     async def fetch_txns(
-        self, account_id: str, start: datetime, end: datetime
-    ) -> list[dict[str, Any]]:
-        return []
+        self,
+        token: TokenPair,
+        account: Account,
+        date_from: date,
+        date_to: date,
+    ) -> AsyncGenerator[RawTxn, None]:
+        if False:
+            yield
+        return

--- a/services/bank_bridge/connectors/tinkoff.py
+++ b/services/bank_bridge/connectors/tinkoff.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime
+from datetime import date, datetime
 from urllib.parse import urlencode
-from typing import Any
+from typing import Any, AsyncGenerator
 
 import httpx
 
-from .base import BaseConnector
+from .base import Account, BaseConnector, RawTxn, TokenPair
 
 
 class TinkoffConnector(BaseConnector):
@@ -20,65 +20,96 @@ class TinkoffConnector(BaseConnector):
     AUTH_URL = "https://id.tinkoff.ru/auth/authorize"
     TOKEN_URL = "https://id.tinkoff.ru/auth/token"
 
-    def __init__(self, user_id: str, token: str | None = None) -> None:
+    def __init__(self, user_id: str, token: TokenPair | None = None) -> None:
         super().__init__(user_id, token)
         self.client_id = os.getenv("TINKOFF_CLIENT_ID", "")
         self.client_secret = os.getenv("TINKOFF_CLIENT_SECRET", "")
         self.redirect_uri = os.getenv("TINKOFF_REDIRECT_URI", "")
-        self.refresh_token: str | None = None
 
-    async def auth(self) -> str:
-        """Return OAuth authorization URL."""
-        params = {
-            "response_type": "code",
-            "client_id": self.client_id,
-            "redirect_uri": self.redirect_uri,
-            "scope": "openid profile payments accounts",
-        }
-        await self._save_token()
-        return self.AUTH_URL + "?" + urlencode(params)
+    async def auth(self, code: str | None, **kwargs: Any) -> TokenPair:
+        """Return OAuth token pair using provided authorization code."""
+        if code is None:
+            url = self.AUTH_URL + "?" + urlencode(
+                {
+                    "response_type": "code",
+                    "client_id": self.client_id,
+                    "redirect_uri": self.redirect_uri,
+                    "scope": "openid profile payments accounts",
+                }
+            )
+            return TokenPair(access_token=url)
 
-    async def refresh(self) -> str:
-        """Refresh OAuth token using stored refresh token."""
-        if not self.refresh_token:
-            raise RuntimeError("missing refresh token")
         payload = {
-            "grant_type": "refresh_token",
+            "grant_type": "authorization_code",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
-            "refresh_token": self.refresh_token,
+            "code": code,
+            "redirect_uri": self.redirect_uri,
         }
         async with httpx.AsyncClient() as client:
             resp = await client.post(self.TOKEN_URL, data=payload, timeout=10)
             resp.raise_for_status()
             data = resp.json()
-        self.token = data.get("access_token")
-        self.refresh_token = data.get("refresh_token", self.refresh_token)
-        if not self.token:
-            raise RuntimeError("no access token")
-        await self._save_token()
-        return self.token
+        pair = TokenPair(
+            access_token=data.get("access_token", ""),
+            refresh_token=data.get("refresh_token"),
+        )
+        await self._save_token(pair)
+        return pair
 
-    async def fetch_accounts(self) -> list[dict[str, Any]]:
-        token = self.token or await self.refresh()
-        headers = {"Authorization": f"Bearer {token}"}
+    async def refresh(self, token: TokenPair) -> TokenPair:
+        """Refresh OAuth token using provided refresh token."""
+        if not token.refresh_token:
+            raise RuntimeError("missing refresh token")
+        payload = {
+            "grant_type": "refresh_token",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "refresh_token": token.refresh_token,
+        }
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(self.TOKEN_URL, data=payload, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+        pair = TokenPair(
+            access_token=data.get("access_token", ""),
+            refresh_token=data.get("refresh_token", token.refresh_token),
+        )
+        if not pair.access_token:
+            raise RuntimeError("no access token")
+        await self._save_token(pair)
+        return pair
+
+    async def fetch_accounts(self, token: TokenPair) -> list[Account]:
+        current = token.access_token
+        if not current and token.refresh_token:
+            token = await self.refresh(token)
+            current = token.access_token
+        headers = {"Authorization": f"Bearer {current}"}
         async with httpx.AsyncClient() as client:
             resp = await client.get(
                 self.BASE_URL + "accounts", headers=headers, timeout=10
             )
             resp.raise_for_status()
             data = resp.json()
-        return data.get("payload", [])
+        return [Account(id=str(a.get("id"))) for a in data.get("payload", [])]
 
     async def fetch_txns(
-        self, account_id: str, start: datetime, end: datetime
-    ) -> list[dict[str, Any]]:
-        token = self.token or await self.refresh()
-        headers = {"Authorization": f"Bearer {token}"}
+        self,
+        token: TokenPair,
+        account: Account,
+        date_from: date,
+        date_to: date,
+    ) -> AsyncGenerator[RawTxn, None]:
+        current = token.access_token
+        if not current and token.refresh_token:
+            token = await self.refresh(token)
+            current = token.access_token
+        headers = {"Authorization": f"Bearer {current}"}
         params = {
-            "account": account_id,
-            "from": int(start.timestamp() * 1000),
-            "to": int(end.timestamp() * 1000),
+            "account": account.id,
+            "from": int(datetime.combine(date_from, datetime.min.time()).timestamp() * 1000),
+            "to": int(datetime.combine(date_to, datetime.min.time()).timestamp() * 1000),
         }
         async with httpx.AsyncClient() as client:
             resp = await client.get(
@@ -89,4 +120,5 @@ class TinkoffConnector(BaseConnector):
             )
             resp.raise_for_status()
             data = resp.json()
-        return data.get("payload", [])
+        for item in data.get("payload", []):
+            yield RawTxn(data=item)


### PR DESCRIPTION
## Summary
- introduce TokenPair, Account and RawTxn dataclasses for bank connectors
- refactor `BaseConnector` to use new models
- update Gazprom, Sber and Tinkoff connectors
- adapt tests to the new connector API

## Testing
- `pytest -q`
- `pytest tests/bank_bridge/test_tinkoff_connector.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd86d50a8832db4a3166f11bc6397