### PR TITLE
Add Kafka consumer and schema validation for bank bridge

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ PyYAML
 
 aiohttp
 aiojobs
+jsonschema

--- a/services/bank_bridge/app.py
+++ b/services/bank_bridge/app.py
@@ -55,9 +55,14 @@ async def _full_sync(bank: str, user_id: str) -> None:
     for account in accounts:
         try:
             async for raw in connector.fetch_txns(token, account, start, end):
-                payload = dict(raw.data)
-                payload.setdefault("user_id", user_id)
-                await normalizer.process(payload)
+                msg = {
+                    "user_id": user_id,
+                    "bank_txn_id": str(
+                        raw.data.get("id") or raw.data.get("bank_txn_id", "")
+                    ),
+                    "payload": dict(raw.data),
+                }
+                await normalizer.process(msg)
                 TXN_COUNT.inc()
         except Exception:
             ERROR_TOTAL.inc()

--- a/services/bank_bridge/consumer.py
+++ b/services/bank_bridge/consumer.py
@@ -1,0 +1,47 @@
+import asyncio
+import json
+import os
+
+from fastapi import FastAPI
+from aiokafka import AIOKafkaConsumer
+
+from . import normalizer, kafka
+
+KAFKA_BROKER_URL = os.getenv("KAFKA_BROKER_URL", "localhost:9092")
+RAW_TOPIC = os.getenv("BANK_RAW_TOPIC", "bank.raw")
+
+app = FastAPI(title="Bank Bridge Consumer")
+
+consumer: AIOKafkaConsumer | None = None
+
+
+async def _consume_loop() -> None:
+    assert consumer
+    async for msg in consumer:
+        data = json.loads(msg.value.decode())
+        await normalizer.process(data)
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    global consumer
+    consumer = AIOKafkaConsumer(
+        RAW_TOPIC,
+        bootstrap_servers=KAFKA_BROKER_URL,
+        enable_auto_commit=True,
+        group_id="bank-bridge",
+    )
+    await consumer.start()
+    asyncio.create_task(_consume_loop())
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    if consumer:
+        await consumer.stop()
+    await kafka.close()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add `consumer` service reading `bank.raw`
- validate input data in `normalizer.process`
- forward normalized data to Kafka or error topic
- update integration to pass messages in new format
- include `jsonschema` runtime dependency

## Testing
- `make bankbridge-tests`

------
https://chatgpt.com/codex/tasks/task_e_686be9f0d3c4832d9dc0e3c9ff117265