### PR TITLE
Fix CI lint error

### DIFF
--- a/services/bank_bridge/normalizer.py
+++ b/services/bank_bridge/normalizer.py
@@ -14,7 +14,9 @@ from backend.app.schemas.posting import PostingCreate
 from . import kafka
 
 BASE_DIR = Path(__file__).resolve().parents[2]
-with open(BASE_DIR / "schemas/bank-bridge/bank.raw/1.0.0/schema.json", "r", encoding="utf-8") as f:
+with open(
+    BASE_DIR / "schemas/bank-bridge/bank.raw/1.0.0/schema.json", "r", encoding="utf-8"
+) as f:
     _schema = json.load(f)
 
 VALIDATOR = Draft202012Validator(_schema)

--- a/tests/bank_bridge/test_contracts.py
+++ b/tests/bank_bridge/test_contracts.py
@@ -33,5 +33,5 @@ def test_examples_match_schema():
 
 @pytest.mark.asyncio
 async def test_openapi_contract():
-    schemathesis = pytest.importorskip("schemathesis")
+    pytest.importorskip("schemathesis")
     pytest.skip("schemathesis execution is not available")

--- a/tests/bank_bridge/test_normalizer.py
+++ b/tests/bank_bridge/test_normalizer.py
@@ -182,5 +182,7 @@ async def test_process_calls_normalize(monkeypatch):
 
     monkeypatch.setattr(normalizer, "normalize_record", fake_norm)
     monkeypatch.setattr(normalizer.kafka, "publish", fake_publish)
-    await normalizer.process({"user_id": str(uuid4()), "bank_txn_id": "11", "payload": {}})
+    await normalizer.process(
+        {"user_id": str(uuid4()), "bank_txn_id": "11", "payload": {}}
+    )
     assert called


### PR DESCRIPTION
## Summary
- remove unused variable to satisfy ruff
- apply Black formatting for updated files

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686c0e244b94832da0bfe059d2475752