### PR TITLE
Add health checks and update status endpoint

### DIFF
--- a/tests/bank_bridge/test_webhook.py
+++ b/tests/bank_bridge/test_webhook.py
@@ -3,7 +3,8 @@ from httpx import AsyncClient, ASGITransport
 from asgi_lifespan import LifespanManager
 
 from services.bank_bridge.app import app, RAW_TOPIC
-from services.bank_bridge import kafka
+from services.bank_bridge import kafka, vault
+from services.bank_bridge.connectors import TokenPair
 
 
 @pytest.mark.asyncio
@@ -33,3 +34,110 @@ async def test_tinkoff_webhook(monkeypatch):
     assert captured["user_id"] == "u1"
     assert captured["bank_txn_id"] == "1"
     assert captured["data"]["payload"]["amount"] == 10
+
+
+class DummyConnector:
+    name = "dummy"
+
+    def __init__(self, user_id: str, token: TokenPair | None = None) -> None:
+        pass
+
+    async def fetch_accounts(self, token: TokenPair) -> list:
+        return [1]
+
+
+@pytest.mark.asyncio
+async def test_status_disconnected(monkeypatch):
+    async def fake_load(bank, user):
+        return None
+
+    monkeypatch.setattr("services.bank_bridge.app._load_token", fake_load)
+    monkeypatch.setattr(
+        "services.bank_bridge.app.get_connector", lambda b: DummyConnector
+    )
+
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as cl:
+            resp = await cl.get("/status/tinkoff")
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "DISCONNECTED"}
+
+
+@pytest.mark.asyncio
+async def test_status_connected(monkeypatch):
+    async def fake_load(bank, user):
+        return TokenPair("at")
+
+    class Conn(DummyConnector):
+        async def fetch_accounts(self, token):
+            return [1]
+
+    monkeypatch.setattr("services.bank_bridge.app._load_token", fake_load)
+    monkeypatch.setattr("services.bank_bridge.app.get_connector", lambda b: Conn)
+
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as cl:
+            resp = await cl.get("/status/tinkoff")
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "CONNECTED"}
+
+
+@pytest.mark.asyncio
+async def test_status_error(monkeypatch):
+    async def fake_load(bank, user):
+        return TokenPair("at")
+
+    class Conn(DummyConnector):
+        async def fetch_accounts(self, token):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("services.bank_bridge.app._load_token", fake_load)
+    monkeypatch.setattr("services.bank_bridge.app.get_connector", lambda b: Conn)
+
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as cl:
+            resp = await cl.get("/status/tinkoff")
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "ERROR"}
+
+
+@pytest.mark.asyncio
+async def test_healthz_ok(monkeypatch):
+    async def fake_get_producer():
+        return object()
+
+    class FakeVault:
+        async def read(self, path):
+            return ""
+
+    monkeypatch.setattr(kafka, "get_producer", fake_get_producer)
+    monkeypatch.setattr(vault, "get_vault_client", lambda: FakeVault())
+
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as cl:
+            resp = await cl.get("/healthz")
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_healthz_error(monkeypatch):
+    async def bad_producer():
+        raise RuntimeError("kafka")
+
+    class FakeVault:
+        async def read(self, path):
+            return ""
+
+    monkeypatch.setattr(kafka, "get_producer", bad_producer)
+    monkeypatch.setattr(vault, "get_vault_client", lambda: FakeVault())
+
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as cl:
+            resp = await cl.get("/healthz")
+            assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- enhance `/status/{bank}` to return connection status
- add Kafka and Vault checks to `/healthz`
- cover new logic with tests

## Testing
- `make bankbridge-tests`

------
https://chatgpt.com/codex/tasks/task_e_686d93037a2c832d9e9bb4726d6b55a6