### PR TITLE
Enable bank bridge contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r backend/requirements-dev.txt
-          pip install jsonschema respx
+          pip install jsonschema respx schemathesis
       - name: Validate schemas
         run: |
           python - <<'PY'
@@ -57,6 +57,13 @@ jobs:
         run: docker compose -f tests/bank_bridge/docker-compose.yml up -d
       - name: Run bankbridge tests
         run: make bankbridge-tests
+      - name: Run contract tests
+        run: |
+          uvicorn services.bank_bridge.app:app --port 8080 --log-level warning &
+          UVICORN_PID=$!
+          sleep 5
+          schemathesis run http://localhost:8080/openapi.json --base-url=http://localhost:8080 --max-examples=10
+          kill $UVICORN_PID
       - name: Stop test environment
         if: always()
         run: docker compose -f tests/bank_bridge/docker-compose.yml down -v

--- a/tests/bank_bridge/test_contracts.py
+++ b/tests/bank_bridge/test_contracts.py
@@ -31,7 +31,12 @@ def test_examples_match_schema():
         Draft202012Validator(schema).validate(example)
 
 
-@pytest.mark.asyncio
-async def test_openapi_contract():
-    pytest.importorskip("schemathesis")
-    pytest.skip("schemathesis execution is not available")
+schemathesis = pytest.importorskip("schemathesis")
+from services.bank_bridge.app import app
+
+schema = schemathesis.openapi.from_asgi("/openapi.json", app)
+
+@schema.parametrize()
+def test_openapi_contract(case):
+    response = case.call_asgi()
+    case.validate_response(response)


### PR DESCRIPTION
## Summary
- activate schemathesis contract test
- install schemathesis in CI and run contract check

## Testing
- `python -m py_compile tests/bank_bridge/test_contracts.py`
- `pytest tests/bank_bridge/test_contracts.py::test_json_schemas_valid -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_686e70c14024832db1c91805ed93ef98