### PR TITLE
Fix ruff import error in test

### DIFF
--- a/tests/bank_bridge/test_contracts.py
+++ b/tests/bank_bridge/test_contracts.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 from jsonschema import Draft202012Validator
+from services.bank_bridge.app import app
 
 schema_dir = Path("schemas/bank-bridge")
 
@@ -32,9 +33,9 @@ def test_examples_match_schema():
 
 
 schemathesis = pytest.importorskip("schemathesis")
-from services.bank_bridge.app import app
 
 schema = schemathesis.openapi.from_asgi("/openapi.json", app)
+
 
 @schema.parametrize()
 def test_openapi_contract(case):


### PR DESCRIPTION
## Summary
- address E402 lint error by moving the app import to the top of `tests/bank_bridge/test_contracts.py`

## Testing
- `make lint`
- `make bankbridge-tests`


------
https://chatgpt.com/codex/tasks/task_e_686e774ffdf0832d8c1569a0ac1bea04