### PR TITLE
Fix bank bridge Kafka handling

### DIFF
--- a/services/bank_bridge/app.py
+++ b/services/bank_bridge/app.py
@@ -295,7 +295,7 @@ async def tinkoff_webhook(
     payload = body.payload
     bank_txn_id = str(payload.get("id") or payload.get("bank_txn_id", ""))
     msg = {"user_id": user_id, "bank_txn_id": bank_txn_id, "payload": payload}
-    await kafka.publish(RAW_TOPIC, user_id, bank_txn_id, msg)
+    asyncio.create_task(kafka.publish(RAW_TOPIC, user_id, bank_txn_id, msg))
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
- avoid blocking when Kafka is unavailable
- send webhook events in the background

## Testing
- `make bankbridge-tests`


------
https://chatgpt.com/codex/tasks/task_e_686fe781eebc832da339cb5ba1802eab