### PR TITLE
Fix import order in bank bridge tests

### DIFF
--- a/tests/bank_bridge/test_tinkoff_connector.py
+++ b/tests/bank_bridge/test_tinkoff_connector.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import asyncio
+import random
 import aiohttp
 from yarl import URL
 
@@ -7,13 +8,12 @@ import pytest
 from aioresponses import aioresponses
 import re
 
+from services.bank_bridge.app import FETCH_LATENCY_MS, RATE_LIMITED
 from services.bank_bridge.connectors.tinkoff import TinkoffConnector
 from services.bank_bridge.connectors.base import TokenPair, Account
+from services.bank_bridge.limits import get_bucket
 
 USER_ID = "00000000-0000-0000-0000-000000000001"
-from services.bank_bridge.limits import get_bucket
-import random
-from services.bank_bridge.app import FETCH_LATENCY_MS, RATE_LIMITED
 
 
 @pytest.fixture(autouse=True)

--- a/tests/bank_bridge/test_webhook.py
+++ b/tests/bank_bridge/test_webhook.py
@@ -4,9 +4,9 @@ from asgi_lifespan import LifespanManager
 
 from services.bank_bridge.app import app, RAW_TOPIC
 from services.bank_bridge import kafka, vault
+from services.bank_bridge.connectors import TokenPair
 
 USER_ID = "00000000-0000-0000-0000-000000000001"
-from services.bank_bridge.connectors import TokenPair
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fix import order in tinkoff connector tests
- fix import order in webhook tests

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6870132e57bc832db3878c05a2b7f63b