### PR TITLE
Fix bank bridge tests for uuid user_id

### DIFF
--- a/tests/bank_bridge/test_integration_full.py
+++ b/tests/bank_bridge/test_integration_full.py
@@ -16,6 +16,8 @@ from services.bank_bridge import normalizer
 from services.bank_bridge.connectors.tinkoff import TinkoffConnector
 from services.bank_bridge.connectors.base import Account, RawTxn, TokenPair
 
+USER_ID = "00000000-0000-0000-0000-000000000001"
+
 COMPOSE_FILE = "tests/bank_bridge/docker-compose.yml"
 
 # Skip tests if Docker is not available or the daemon isn't running. This allows
@@ -127,7 +129,7 @@ async def test_sync_cycle(client):
     except Exception:
         pytest.skip("Kafka is not available")
     try:
-        resp = await client.post("/sync/tinkoff")
+        resp = await client.post(f"/sync/tinkoff?user_id={USER_ID}")
         assert resp.status_code == 200
         raw_msg = await raw_consumer.getone()
         raw_data = json.loads(raw_msg.value.decode())

--- a/tests/bank_bridge/test_webhook.py
+++ b/tests/bank_bridge/test_webhook.py
@@ -71,7 +71,7 @@ async def test_status_disconnected(monkeypatch):
     async with LifespanManager(app):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as cl:
-            resp = await cl.get("/status/tinkoff")
+            resp = await cl.get(f"/status/tinkoff?user_id={USER_ID}")
             assert resp.status_code == 200
             assert resp.json() == {"status": "DISCONNECTED"}
 
@@ -91,7 +91,7 @@ async def test_status_connected(monkeypatch):
     async with LifespanManager(app):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as cl:
-            resp = await cl.get("/status/tinkoff")
+            resp = await cl.get(f"/status/tinkoff?user_id={USER_ID}")
             assert resp.status_code == 200
             assert resp.json() == {"status": "CONNECTED"}
 
@@ -111,7 +111,7 @@ async def test_status_error(monkeypatch):
     async with LifespanManager(app):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as cl:
-            resp = await cl.get("/status/tinkoff")
+            resp = await cl.get(f"/status/tinkoff?user_id={USER_ID}")
             assert resp.status_code == 200
             assert resp.json() == {"status": "ERROR"}
 


### PR DESCRIPTION
## Summary
- adjust webhook status tests to pass user_id
- update integration sync test with user_id parameter

## Testing
- `make bankbridge-tests`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687018340930832da76c98e4ec4d3610