### PR TITLE
Fix lint error

### DIFF
--- a/tests/bank_bridge/test_tinkoff_connector.py
+++ b/tests/bank_bridge/test_tinkoff_connector.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 import asyncio
 import random
-import aiohttp
 from yarl import URL
 
 import pytest


### PR DESCRIPTION
## Summary
- remove unused `aiohttp` import causing F401 lint error

## Testing
- `pre-commit run ruff --files tests/bank_bridge/test_tinkoff_connector.py`
- `pre-commit run black --files tests/bank_bridge/test_tinkoff_connector.py`
- `pre-commit run mypy --files tests/bank_bridge/test_tinkoff_connector.py`
- `make lint`
- `make bankbridge-tests`


------
https://chatgpt.com/codex/tasks/task_e_68702fc52ed0832d803ad9c8ff65a0fd