### PR TITLE
Fix lint failure due to unformatted files

### DIFF
--- a/services/bank_bridge/normalizer.py
+++ b/services/bank_bridge/normalizer.py
@@ -12,10 +12,14 @@ from jsonschema import Draft202012Validator
 from . import kafka
 
 BASE_DIR = Path(__file__).resolve().parents[2]
-with open(BASE_DIR / "schemas/bank-bridge/bank.raw/1.0.0/schema.json", "r", encoding="utf-8") as f:
+with open(
+    BASE_DIR / "schemas/bank-bridge/bank.raw/1.0.0/schema.json", "r", encoding="utf-8"
+) as f:
     _raw_schema = json.load(f)
 
-with open(BASE_DIR / "schemas/bank-bridge/bank.norm/1.0.0/schema.json", "r", encoding="utf-8") as f:
+with open(
+    BASE_DIR / "schemas/bank-bridge/bank.norm/1.0.0/schema.json", "r", encoding="utf-8"
+) as f:
     _norm_schema = json.load(f)
 
 RAW_VALIDATOR = Draft202012Validator(_raw_schema)

--- a/tests/bank_bridge/test_normalizer.py
+++ b/tests/bank_bridge/test_normalizer.py
@@ -7,7 +7,9 @@ from jsonschema import Draft202012Validator
 
 from services.bank_bridge import normalizer
 
-SCHEMA_PATH = Path(normalizer.BASE_DIR) / "schemas/bank-bridge/bank.norm/1.0.0/schema.json"
+SCHEMA_PATH = (
+    Path(normalizer.BASE_DIR) / "schemas/bank-bridge/bank.norm/1.0.0/schema.json"
+)
 with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
     NORM_SCHEMA = json.load(f)
 VALIDATOR = Draft202012Validator(NORM_SCHEMA)


### PR DESCRIPTION
## Summary
- fix formatting in `services/bank_bridge/normalizer.py`
- fix formatting in `tests/bank_bridge/test_normalizer.py`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68703e8b03c8832d91a0fa46dd7d095c