### PR TITLE
Implement structured error handling

### DIFF
--- a/services/bank_bridge/app.py
+++ b/services/bank_bridge/app.py
@@ -125,6 +125,19 @@ async def _full_sync(bank: BankName, user_id: str) -> None:
     except Exception:
         ERROR_TOTAL.inc()
         logger.error("accounts_error", extra={"bank": bank})
+        await kafka.publish(
+            "bank.err",
+            user_id,
+            "",
+            {
+                "user_id": user_id,
+                "external_id": "",
+                "bank_id": bank,
+                "error_code": "CONNECTOR_ERROR",
+                "stage": "connector",
+                "payload": {"operation": "fetch_accounts"},
+            },
+        )
         return
 
     end = date.today()
@@ -144,6 +157,19 @@ async def _full_sync(bank: BankName, user_id: str) -> None:
         except Exception:
             ERROR_TOTAL.inc()
             logger.error("sync_error", extra={"bank": bank})
+            await kafka.publish(
+                "bank.err",
+                user_id,
+                "",
+                {
+                    "user_id": user_id,
+                    "external_id": "",
+                    "bank_id": bank,
+                    "error_code": "CONNECTOR_ERROR",
+                    "stage": "connector",
+                    "payload": {"operation": "fetch_txns", "account": account.id},
+                },
+            )
 
 
 async def _refresh_tokens_once(user_id: str = "default") -> None:
@@ -158,6 +184,19 @@ async def _refresh_tokens_once(user_id: str = "default") -> None:
         except Exception:
             ERROR_TOTAL.inc()
             logger.error("refresh_error", extra={"bank": bank})
+            await kafka.publish(
+                "bank.err",
+                user_id,
+                "",
+                {
+                    "user_id": user_id,
+                    "external_id": "",
+                    "bank_id": bank,
+                    "error_code": "CONNECTOR_ERROR",
+                    "stage": "refresh",
+                    "payload": {},
+                },
+            )
 
 
 async def _refresh_tokens_loop() -> None:

--- a/tests/bank_bridge/test_connector_errors.py
+++ b/tests/bank_bridge/test_connector_errors.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from services.bank_bridge import app as service_app, kafka
+from services.bank_bridge.app import _full_sync, BankName
+from typing import AsyncGenerator
+from services.bank_bridge.connectors.base import (
+    BaseConnector,
+    TokenPair,
+    Account,
+    RawTxn,
+)
+
+SCHEMA_PATH = (
+    Path(service_app.__file__).resolve().parents[2]
+    / "schemas/bank-bridge/bank.err/1.0.0/schema.json"
+)
+with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+    ERR_SCHEMA = json.load(f)
+ERR_VALIDATOR = Draft202012Validator(ERR_SCHEMA)
+
+
+class DummyAccountsError(BaseConnector):
+    name = "dummy"
+    display = "Dummy"
+
+    async def auth(self, code: str | None, **kwargs):
+        return TokenPair("t")
+
+    async def refresh(self, token: TokenPair) -> TokenPair:
+        return token
+
+    async def fetch_accounts(self, token: TokenPair):
+        raise RuntimeError("boom")
+
+    async def fetch_txns(
+        self, token: TokenPair, account: Account, date_from, date_to
+    ) -> AsyncGenerator[RawTxn, None]:
+        if False:
+            yield
+
+
+class DummyTxnsError(DummyAccountsError):
+    async def fetch_accounts(self, token: TokenPair):
+        return [Account(id="acc1")]
+
+    async def fetch_txns(
+        self, token: TokenPair, account: Account, date_from, date_to
+    ) -> AsyncGenerator[RawTxn, None]:
+        raise RuntimeError("fail")
+
+
+@pytest.mark.asyncio
+async def test_full_sync_accounts_error(monkeypatch):
+    captured = {}
+
+    async def fake_publish(topic, user_id, bank_txn_id, data):
+        captured.update({"topic": topic, "data": data})
+
+    async def fake_load(bank, user):
+        return TokenPair("t")
+
+    monkeypatch.setattr(service_app, "_load_token", fake_load)
+    monkeypatch.setattr(service_app, "get_connector", lambda b: DummyAccountsError)
+    monkeypatch.setattr(kafka, "publish", fake_publish)
+
+    await _full_sync(BankName.TINKOFF, str(uuid4()))
+
+    assert captured["topic"] == "bank.err"
+    ERR_VALIDATOR.validate(captured["data"])
+    assert captured["data"]["error_code"] == "CONNECTOR_ERROR"
+    assert captured["data"]["stage"] == "connector"
+    assert captured["data"]["bank_id"] == "tinkoff"
+
+
+@pytest.mark.asyncio
+async def test_full_sync_txns_error(monkeypatch):
+    captured = {}
+
+    async def fake_publish(topic, user_id, bank_txn_id, data):
+        captured.update({"topic": topic, "data": data})
+
+    async def fake_load(bank, user):
+        return TokenPair("t")
+
+    monkeypatch.setattr(service_app, "_load_token", fake_load)
+    monkeypatch.setattr(service_app, "get_connector", lambda b: DummyTxnsError)
+    monkeypatch.setattr(kafka, "publish", fake_publish)
+
+    await _full_sync(BankName.TINKOFF, str(uuid4()))
+
+    assert captured["topic"] == "bank.err"
+    ERR_VALIDATOR.validate(captured["data"])
+    assert captured["data"]["error_code"] == "CONNECTOR_ERROR"
+    assert captured["data"]["stage"] == "connector"
+    assert captured["data"]["bank_id"] == "tinkoff"


### PR DESCRIPTION
## Summary
- send structured errors from `normalizer.process`
- forward connector errors to Kafka with error details
- update normalizer tests to cover new error format
- add tests for connector error reporting

## Testing
- `ruff check .`
- `black --check .`
- `mypy backend/app`
- `pytest --cov=services/bank_bridge --cov-config=.coveragerc.bankbridge --cov-fail-under=90 tests/bank_bridge`

------
https://chatgpt.com/codex/tasks/task_e_6870bbaec144832d8a85b0ed18e2ce95