### PR TITLE
Add expiry to bank token

### DIFF
--- a/services/bank_bridge/app.py
+++ b/services/bank_bridge/app.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 import asyncio
 from typing import Any
 
@@ -105,9 +105,12 @@ async def _load_token(bank: BankName, user_id: str) -> TokenPair | None:
     if not data:
         return None
     obj = json.loads(data)
+    expiry_val = obj.get("expiry")
+    expiry = datetime.fromisoformat(expiry_val) if expiry_val else None
     return TokenPair(
         access_token=obj.get("access_token", ""),
         refresh_token=obj.get("refresh_token"),
+        expiry=expiry,
     )
 
 

--- a/services/bank_bridge/connectors/base.py
+++ b/services/bank_bridge/connectors/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from typing import Any, AsyncGenerator
 
 import asyncio
@@ -22,6 +22,7 @@ class TokenPair:
 
     access_token: str
     refresh_token: str | None = None
+    expiry: datetime | None = None
 
 
 @dataclass
@@ -66,6 +67,8 @@ class BaseConnector(ABC):
         data = {"access_token": token.access_token}
         if token.refresh_token:
             data["refresh_token"] = token.refresh_token
+        if token.expiry:
+            data["expiry"] = token.expiry.isoformat()
         await self.vault.write(
             f"bank_tokens/{self.name}/{self.user_id}", json.dumps(data)
         )

--- a/services/bank_bridge/connectors/tinkoff.py
+++ b/services/bank_bridge/connectors/tinkoff.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from urllib.parse import urlencode
 from typing import Any, AsyncGenerator
 
@@ -60,9 +60,16 @@ class TinkoffConnector(BaseConnector):
             headers=headers,
             auth=False,
         )
+        expiry = None
+        if "expires_in" in data:
+            try:
+                expiry = datetime.utcnow() + timedelta(seconds=int(data["expires_in"]))
+            except Exception:
+                expiry = None
         pair = TokenPair(
             access_token=data.get("access_token", ""),
             refresh_token=data.get("refresh_token"),
+            expiry=expiry,
         )
         await self._save_token(pair)
         return pair
@@ -83,9 +90,16 @@ class TinkoffConnector(BaseConnector):
             headers=headers,
             auth=False,
         )
+        expiry = None
+        if "expires_in" in data:
+            try:
+                expiry = datetime.utcnow() + timedelta(seconds=int(data["expires_in"]))
+            except Exception:
+                expiry = None
         pair = TokenPair(
             access_token=data.get("access_token", ""),
             refresh_token=data.get("refresh_token", token.refresh_token),
+            expiry=expiry,
         )
         if not pair.access_token:
             raise RuntimeError("no access token")


### PR DESCRIPTION
## Summary
- extend `TokenPair` dataclass with optional expiry datetime
- persist token expiry in Vault
- compute expiry in Tinkoff connector when `expires_in` is returned
- adjust tests for the new field

## Testing
- `pytest tests/bank_bridge/test_tinkoff_connector.py::test_auth -q`
- `pytest tests/bank_bridge/test_tinkoff_connector.py::test_refresh_success -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e1d20fd8832d897dbacedd575a9c