### PR TITLE
Implement new backoff delay

### DIFF
--- a/services/bank_bridge/connectors/base.py
+++ b/services/bank_bridge/connectors/base.py
@@ -120,7 +120,7 @@ class BaseConnector(ABC):
                             await resp.release()
                             if attempt == 4:
                                 resp.raise_for_status()
-                            delay = min(512, 2**attempt)
+                            delay = min(512, 4 * 2**attempt)
                             jitter = delay * 0.15
                             delay = random.uniform(delay - jitter, delay + jitter)
                             await asyncio.sleep(delay)
@@ -157,7 +157,7 @@ class BaseConnector(ABC):
 
                     if attempt == 4:
                         raise RuntimeError("max retries exceeded")
-                    delay = min(512, 2**attempt)
+                    delay = min(512, 4 * 2**attempt)
                     jitter = delay * 0.15
                     delay = random.uniform(delay - jitter, delay + jitter)
                     await asyncio.sleep(delay)

--- a/tests/bank_bridge/test_tinkoff_connector.py
+++ b/tests/bank_bridge/test_tinkoff_connector.py
@@ -342,8 +342,8 @@ async def test_request_backoff(monkeypatch):
         rsx.get(url, status=200)
         await c._request("GET", url, auth=False)
 
-    assert sleeps == [pytest.approx(0.85)]
-    assert args == [(0.85, 1.15)]
+    assert sleeps == [pytest.approx(3.4)]
+    assert args == [(3.4, 4.6)]
 
 
 @pytest.mark.asyncio
@@ -383,7 +383,7 @@ async def test_request_backoff_rate_limit(monkeypatch):
         rsx.get(url, payload={}, status=200)
         await c._request("GET", url, auth=False)
 
-    assert sleeps == [pytest.approx(0.85)]
-    assert args == [(0.85, 1.15)]
+    assert sleeps == [pytest.approx(3.4)]
+    assert args == [(3.4, 4.6)]
     assert labels == ["tinkoff"]
     assert calls == [1]


### PR DESCRIPTION
## Summary
- increase request backoff delay in `_request`
- jitter around the delay remains ±15%
- update tests for new delay logic

## Testing
- `pytest tests/bank_bridge/test_tinkoff_connector.py::test_request_backoff -q`
- `pytest tests/bank_bridge/test_tinkoff_connector.py::test_request_backoff_rate_limit -q`
- `pytest tests/bank_bridge/test_tinkoff_connector.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6870f5398c38832db895bd040c8fbb05