### PR TITLE
Fix log field name and update promtail example

### DIFF
--- a/docs/bank-bridge/promtail-example.yml
+++ b/docs/bank-bridge/promtail-example.yml
@@ -5,6 +5,20 @@ clients:
 
 scrape_configs:
   - job_name: bank-bridge
+    pipeline_stages:
+      - cri: {}
+      - json:
+          expressions:
+            ts: ts
+            level: level
+            msg: msg
+            bank: bank
+      - labels:
+          level:
+          bank:
+      - timestamp:
+          source: ts
+          format: 2006-01-02T15:04:05Z0700
     static_configs:
       - targets: [localhost]
         labels:

--- a/services/bank_bridge/app.py
+++ b/services/bank_bridge/app.py
@@ -240,7 +240,7 @@ class JsonFormatter(logging.Formatter):
         data = {
             "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S%z"),
             "level": record.levelname.lower(),
-            "message": record.getMessage(),
+            "msg": record.getMessage(),
         }
         if hasattr(record, "bank"):
             data["bank"] = record.bank


### PR DESCRIPTION
## Summary
- rename `JsonFormatter` message field to `msg`
- update Promtail example with JSON pipeline for the new field

## Testing
- `make bankbridge-tests`
- `make ci`


------
https://chatgpt.com/codex/tasks/task_e_68711497e064832db1d764fcc280ad8e