### PR TITLE
Fix timezone in Tinkoff connector

### DIFF
--- a/services/bank_bridge/connectors/tinkoff.py
+++ b/services/bank_bridge/connectors/tinkoff.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 import os
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from urllib.parse import urlencode
 from typing import Any, AsyncGenerator
 
@@ -63,7 +63,7 @@ class TinkoffConnector(BaseConnector):
         expiry = None
         if "expires_in" in data:
             try:
-                expiry = datetime.utcnow() + timedelta(seconds=int(data["expires_in"]))
+                expiry = datetime.now(timezone.utc) + timedelta(seconds=int(data["expires_in"]))
             except Exception:
                 expiry = None
         pair = TokenPair(
@@ -93,7 +93,7 @@ class TinkoffConnector(BaseConnector):
         expiry = None
         if "expires_in" in data:
             try:
-                expiry = datetime.utcnow() + timedelta(seconds=int(data["expires_in"]))
+                expiry = datetime.now(timezone.utc) + timedelta(seconds=int(data["expires_in"]))
             except Exception:
                 expiry = None
         pair = TokenPair(


### PR DESCRIPTION
## Summary
- use timezone-aware datetimes in Tinkoff connector
- remove leftover package marker from test directory

## Testing
- `pytest -q tests/bank_bridge/test_tinkoff_connector.py::test_refresh_success -q`
- `pytest -q tests/bank_bridge/test_tinkoff_connector.py::test_auth -q`


------
https://chatgpt.com/codex/tasks/task_e_687127075c78832dac85597e06c8de2c