### PR TITLE
Fix ledger nested transaction commit

### DIFF
--- a/backend/app/services/ledger.py
+++ b/backend/app/services/ledger.py
@@ -58,11 +58,9 @@ async def post_entry(
                     transaction_id=tx_obj.id,
                 )
             )
-    if started:
-        await db.refresh(tx_obj)
-    else:
-        await db.commit()
-        await db.refresh(tx_obj)
+    if not started:
+        await db.flush()
+    await db.refresh(tx_obj)
     if tx_obj.posted_at.tzinfo is None:
         tx_obj.posted_at = tx_obj.posted_at.replace(tzinfo=timezone.utc)
     else:


### PR DESCRIPTION
## Summary
- prevent unwanted commit in `ledger.post_entry`
- test nested transaction behaviour
- install telegram dependency for tests

## Testing
- `pytest tests/unit/test_services_ledger.py::test_post_entry_nested_transaction -q`
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_687127075c78832dac85597e06c8de2c