### PR TITLE
Add mock services for bank_bridge tests

### DIFF
--- a/docs/bank-bridge/README.md
+++ b/docs/bank-bridge/README.md
@@ -97,13 +97,16 @@ scrape_configs:
 
 ## Тестовый контур
 
-Для локального тестирования используется `tests/bank_bridge/docker-compose.yml`. Он поднимает только Kafka. Запуск:
+Для локального тестирования используется `tests/bank_bridge/docker-compose.yml`. Он поднимает Kafka и несколько заглушек. Запуск:
 
 ```bash
 docker compose -f tests/bank_bridge/docker-compose.yml up -d
 ```
 
-После старта доступен порт 9092 для подключения тестов.
+После старта доступны следующие сервисы:
+- Kafka на порту 9092;
+- mock bank-api на порту 8081;
+- mock Core API на порту 8200.
 
 Интеграционные тесты запускаются командой:
 

--- a/tests/bank_bridge/docker-compose.yml
+++ b/tests/bank_bridge/docker-compose.yml
@@ -6,3 +6,13 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
     ports:
       - "9092:9092"
+  bank-api:
+    build: ./mock_services/bank_api
+    volumes:
+      - ./stubs:/data:ro
+    ports:
+      - "8081:80"
+  core-api:
+    build: ./mock_services/core_api
+    ports:
+      - "8200:8200"

--- a/tests/bank_bridge/mock_services/bank_api/Dockerfile
+++ b/tests/bank_bridge/mock_services/bank_api/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN pip install --no-cache-dir fastapi uvicorn[standard]
+COPY server.py /app/
+CMD ["python", "server.py"]

--- a/tests/bank_bridge/mock_services/bank_api/server.py
+++ b/tests/bank_bridge/mock_services/bank_api/server.py
@@ -1,0 +1,25 @@
+import json
+import os
+from fastapi import FastAPI
+import uvicorn
+
+app = FastAPI()
+BASE_DIR = os.getenv("STUB_DATA", "/data")
+
+
+@app.get("/accounts")
+async def accounts():
+    path = os.path.join(BASE_DIR, "accounts.json")
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@app.get("/transactions")
+async def transactions():
+    path = os.path.join(BASE_DIR, "transactions.json")
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=80)

--- a/tests/bank_bridge/mock_services/core_api/Dockerfile
+++ b/tests/bank_bridge/mock_services/core_api/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN pip install --no-cache-dir fastapi uvicorn[standard]
+COPY server.py /app/
+CMD ["python", "server.py"]

--- a/tests/bank_bridge/mock_services/core_api/server.py
+++ b/tests/bank_bridge/mock_services/core_api/server.py
@@ -1,0 +1,15 @@
+import json
+from fastapi import FastAPI
+import uvicorn
+
+app = FastAPI()
+TOKEN = json.dumps({"access_token": "x"})
+
+
+@app.get("/v1/secret/bank_tokens/{bank}/{user_id}")
+async def read_token(bank: str, user_id: str):
+    return {"data": {"value": TOKEN}}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8200)


### PR DESCRIPTION
## Summary
- extend bank_bridge docker-compose with stub bank and core APIs
- use the stubs in `test_integration_full`
- document available services for test environment

## Testing
- `ruff check .`
- `black --check .`
- `mypy backend/app`
- `pytest tests/bank_bridge/test_integration_full.py::test_sync_cycle -vv`
- `make bankbridge-tests`

------
https://chatgpt.com/codex/tasks/task_e_68716208e3d0832d80d5714759d08efa