### PR TITLE
Add Tinkoff sandbox Playwright test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r backend/requirements-dev.txt
-          pip install jsonschema respx schemathesis
+          pip install jsonschema respx schemathesis playwright
+      - name: Install Playwright browsers
+        run: playwright install chromium
       - name: Validate schemas
         run: |
           python - <<'PY'
@@ -57,6 +59,12 @@ jobs:
         run: docker compose -f tests/bank_bridge/docker-compose.yml up -d
       - name: Run bankbridge tests
         run: make bankbridge-tests
+      - name: Run sandbox auth test
+        run: python tests/bank_bridge/tinkoff_sandbox.py
+        env:
+          TINKOFF_SANDBOX_LOGIN: ${{ secrets.TINKOFF_SANDBOX_LOGIN }}
+          TINKOFF_SANDBOX_PASSWORD: ${{ secrets.TINKOFF_SANDBOX_PASSWORD }}
+        continue-on-error: true
       - name: Run contract tests
         run: |
           uvicorn services.bank_bridge.app:app --port 8080 --log-level warning &

--- a/docs/bank-bridge/README.md
+++ b/docs/bank-bridge/README.md
@@ -116,6 +116,29 @@ pytest tests/bank_bridge
 
 или через `make bankbridge-tests`.
 
+### Проверка авторизации в песочнице
+
+Для тестирования OAuth‑процесса с песочницей Тинькофф используется
+скрипт `tests/bank_bridge/tinkoff_sandbox.py` на базе Playwright. Он
+выполняет вход под тестовой учётной записью и ожидает редирект на
+указанный в переменных окружения URL.
+
+Перед запуском необходимо установить Playwright и загрузить браузер:
+
+```bash
+pip install playwright
+playwright install chromium
+```
+
+После этого скрипт запускается командой:
+
+```bash
+python tests/bank_bridge/tinkoff_sandbox.py
+```
+
+Требуются переменные `TINKOFF_SANDBOX_LOGIN` и
+`TINKOFF_SANDBOX_PASSWORD`.
+
 ## Локальное развёртывание
 
 1. Скопируйте `env/.env.example` в `.env` и заполните переменные для доступа к банкам.

--- a/tests/bank_bridge/tinkoff_sandbox.py
+++ b/tests/bank_bridge/tinkoff_sandbox.py
@@ -1,0 +1,35 @@
+import asyncio
+import os
+import re
+from playwright.async_api import async_playwright
+from services.bank_bridge.connectors.tinkoff import TinkoffConnector, TokenPair
+
+LOGIN = os.getenv("TINKOFF_SANDBOX_LOGIN")
+PASSWORD = os.getenv("TINKOFF_SANDBOX_PASSWORD")
+
+
+async def main() -> None:
+    if not LOGIN or not PASSWORD:
+        print("Missing sandbox credentials, skipping")
+        return
+    connector = TinkoffConnector(user_id="sandbox-test", token=None)
+    pair: TokenPair = await connector.auth(None)
+    auth_url = pair.access_token
+    redirect_uri = connector.redirect_uri
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        await page.goto(auth_url)
+        await page.fill('input[type="text"]', LOGIN)
+        await page.fill('input[type="password"]', PASSWORD)
+        await page.click('button[type="submit"]')
+        await page.wait_for_url(
+            re.compile(re.escape(redirect_uri) + r".*"), timeout=15000
+        )
+        await browser.close()
+        print("Sandbox authorization successful")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- test sandbox OAuth flow with Playwright
- run sandbox check in CI only when creds are present
- document Playwright usage for bank bridge

## Testing
- `make bankbridge-tests`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_687166c79100832d8203f21897233e73