### PR TITLE
Fix currency refresh logic

### DIFF
--- a/backend/app/currency.py
+++ b/backend/app/currency.py
@@ -15,7 +15,7 @@ async def get_rate(code: str) -> float:
     """Вернуть курс валюты к рублю."""
     global _rates, _last_update
     now = datetime.now(timezone.utc)
-    if not _last_update or (now - _last_update).seconds > 3600:
+    if not _last_update or (now - _last_update).total_seconds() > 3600:
         try:
             async with httpx.AsyncClient() as client:
                 resp = await client.get(_CBR_URL, timeout=10)

--- a/tests/unit/test_currency_module.py
+++ b/tests/unit/test_currency_module.py
@@ -1,0 +1,43 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+import httpx
+
+from backend.app import currency
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+class DummyClient:
+    def __init__(self, data):
+        self._data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, url, timeout=10):
+        return DummyResponse(self._data)
+
+
+@pytest.mark.asyncio
+async def test_get_rate_refresh(monkeypatch):
+    data = {"Valute": {"USD": {"Value": 60.0}}}
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(data))
+
+    currency._last_update = datetime.now(timezone.utc) - timedelta(days=1)
+    currency._rates = {"RUB": 1.0, "USD": 50.0}
+
+    rate = await currency.get_rate("USD")
+    assert rate == 60.0
+    assert currency._rates["USD"] == 60.0


### PR DESCRIPTION
## Summary
- ensure currency rates refresh if last update was more than an hour ago
- add regression test for currency rate refresh

## Testing
- `ruff check tests/unit/test_currency_module.py backend/app/currency.py`
- `black --check tests/unit/test_currency_module.py backend/app/currency.py`
- `mypy backend/app`
- `pytest tests/unit/test_currency_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68716bc63444832da0b557647a780729