### PR TITLE
Fix incorrect transaction commit in ledger service

### DIFF
--- a/backend/app/services/ledger.py
+++ b/backend/app/services/ledger.py
@@ -59,9 +59,9 @@ async def post_entry(
                 )
             )
     if started:
+        await db.commit()
         await db.refresh(tx_obj)
     else:
-        await db.commit()
         await db.refresh(tx_obj)
     if tx_obj.posted_at.tzinfo is None:
         tx_obj.posted_at = tx_obj.posted_at.replace(tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- ensure `post_entry` commits when starting a transaction

## Testing
- `ruff check .`
- `mypy backend`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68716bc63444832da0b557647a780729