### PR TITLE
Enable Schemathesis contract test

### DIFF
--- a/tests/bank_bridge/test_contracts.py
+++ b/tests/bank_bridge/test_contracts.py
@@ -92,7 +92,6 @@ schemathesis = pytest.importorskip("schemathesis")
 schema = schemathesis.openapi.from_asgi("/openapi.json", app)
 
 
-@pytest.mark.skip("schemathesis compatibility issues")
 @schema.parametrize()
 def test_openapi_contract(case):
     response = case.call()


### PR DESCRIPTION
## Summary
- enable bank bridge openapi contract test

## Testing
- `make bankbridge-tests`

------
https://chatgpt.com/codex/tasks/task_e_6871a1e2f9b0832d9cc8ca3cbd6a4cd4