### PR TITLE
Add bank bridge OpenAPI generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,23 @@ jobs:
         with:
           message: 'chore: update openapi spec [skip ci]'
           add: docs/api/openapi.yaml
+
+  openapi-bankbridge:
+    runs-on: ubuntu-latest
+    needs: bankbridge-tests
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Generate Bank Bridge OpenAPI spec
+        run: make openapi-bankbridge
+      - name: Commit updated spec
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: 'chore: update bank-bridge openapi spec [skip ci]'
+          add: docs/bank-bridge/openapi.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev ci lint test devcontainer proto openapi demo_user bankbridge-tests
+.PHONY: dev ci lint test devcontainer proto openapi openapi-bankbridge demo_user bankbridge-tests
 
 
 dev:
@@ -23,6 +23,9 @@ proto:
 
 openapi:
 	python -m backend.scripts.generate_openapi
+
+openapi-bankbridge:
+	python -m services.bank_bridge.scripts.generate_openapi
 
 demo_user:
 	python -m backend.scripts.create_demo_user

--- a/docs/bank-bridge/openapi.yaml
+++ b/docs/bank-bridge/openapi.yaml
@@ -1,0 +1,244 @@
+openapi: 3.1.0
+info:
+  title: Bank Bridge
+  version: 0.1.0
+paths:
+  /healthz:
+    get:
+      summary: Health
+      description: Return service health status.
+      operationId: health_healthz_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+  /connect/{bank}:
+    post:
+      summary: Connect
+      description: Return authorization URL for the requested bank.
+      operationId: connect_connect__bank__post
+      parameters:
+      - name: bank
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/BankName'
+      - name: user_id
+        in: query
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          pattern: ^[0-9a-fA-F-]{36}$
+          default: 00000000-0000-0000-0000-000000000001
+          title: User Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Connect Connect  Bank  Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /status/{bank}:
+    get:
+      summary: Status
+      description: Check connection status for the bank.
+      operationId: status_status__bank__get
+      parameters:
+      - name: bank
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/BankName'
+      - name: user_id
+        in: query
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          pattern: ^[0-9a-fA-F-]{36}$
+          default: 00000000-0000-0000-0000-000000000001
+          title: User Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Status Status  Bank  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /sync/{bank}:
+    post:
+      summary: Sync
+      description: Schedule full data synchronization with bank.
+      operationId: sync_sync__bank__post
+      parameters:
+      - name: bank
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/BankName'
+      - name: user_id
+        in: query
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          pattern: ^[0-9a-fA-F-]{36}$
+          default: 00000000-0000-0000-0000-000000000001
+          title: User Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Sync Sync  Bank  Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /webhook/tinkoff/{user_id}:
+    post:
+      summary: Tinkoff Webhook
+      description: Handle Tinkoff sandbox operation webhook.
+      operationId: tinkoff_webhook_webhook_tinkoff__user_id__post
+      parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: ^[0-9a-fA-F-]{36}$
+          title: User Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TinkoffWebhook'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Tinkoff Webhook Webhook Tinkoff  User Id  Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /metrics:
+    get:
+      summary: Metrics
+      description: Expose Prometheus metrics.
+      operationId: metrics_metrics_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+            text/plain: {}
+components:
+  schemas:
+    BankName:
+      type: string
+      enum:
+      - tinkoff
+      - sber
+      - gazprom
+      - alfa
+      - vtb
+      title: BankName
+      description: Supported bank connectors.
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    HealthStatus:
+      properties:
+        status:
+          type: string
+          title: Status
+      type: object
+      required:
+      - status
+      title: HealthStatus
+      description: Service health check response.
+    TinkoffEvent:
+      type: string
+      enum:
+      - operation
+      title: TinkoffEvent
+      description: Supported webhook events.
+    TinkoffWebhook:
+      properties:
+        event:
+          $ref: '#/components/schemas/TinkoffEvent'
+          description: Event type
+        payload:
+          additionalProperties: true
+          type: object
+          title: Payload
+      type: object
+      required:
+      - event
+      title: TinkoffWebhook
+      description: Webhook payload for Tinkoff operations.
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError

--- a/services/bank_bridge/scripts/generate_openapi.py
+++ b/services/bank_bridge/scripts/generate_openapi.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import yaml
+
+from services.bank_bridge.app import app
+
+
+def main() -> None:
+    schema = app.openapi()
+    fixed_paths = {}
+    for path, data in schema["paths"].items():
+        if path.endswith(":"):
+            path = path.rstrip(":")
+        fixed_paths[path] = data
+    schema["paths"] = fixed_paths
+
+    docs_dir = Path("docs/bank-bridge")
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    with open(docs_dir / "openapi.yaml", "w", encoding="utf-8") as f:
+        yaml.safe_dump(schema, f, allow_unicode=True, sort_keys=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate OpenAPI spec for bank bridge
- expose make target to generate the spec
- commit generated bank bridge spec
- run spec generation for bank bridge in CI

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6871a781f6f4832da0ff8c914efe3bfd