### PR TITLE
Add bank bridge consumer container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,5 +77,18 @@ services:
         limits:
           cpus: "1.0"
           memory: 512m
+
+  bank-bridge-consumer:
+    build:
+      context: .
+      dockerfile: services/bank_bridge/consumer.Dockerfile
+    env_file: .env
+    depends_on:
+      - kafka
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512m
 volumes:
   db_data:

--- a/docs/bank-bridge/README.md
+++ b/docs/bank-bridge/README.md
@@ -174,11 +174,18 @@ python tests/bank_bridge/tinkoff_sandbox.py
 ## Локальное развёртывание
 
 1. Скопируйте `env/.env.example` в `.env` и заполните переменные для доступа к банкам.
-2. Соберите Docker‑образ и запустите контейнер:
+2. Соберите Docker‑образ и запустите контейнер API:
 
 ```bash
 docker build -t bank-bridge -f services/bank_bridge/Dockerfile .
 docker run --env-file .env -p 8080:8080 bank-bridge
+```
+
+3. В отдельном контейнере запустите consumer Kafka:
+
+```bash
+docker build -t bank-bridge-consumer -f services/bank_bridge/consumer.Dockerfile .
+docker run --env-file .env bank-bridge-consumer
 ```
 
 Сервис будет доступен на `http://localhost:8080`. Для разработки можно запустить его напрямую:

--- a/services/bank_bridge/consumer.Dockerfile
+++ b/services/bank_bridge/consumer.Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "services.bank_bridge.consumer:app", "--host", "0.0.0.0", "--port", "8081"]

--- a/tests/bank_bridge/docker-compose.yml
+++ b/tests/bank_bridge/docker-compose.yml
@@ -16,3 +16,12 @@ services:
     build: ./mock_services/core_api
     ports:
       - "8200:8200"
+
+  bank-bridge-consumer:
+    build:
+      context: ../..
+      dockerfile: services/bank_bridge/consumer.Dockerfile
+    environment:
+      - KAFKA_BROKER_URL=kafka:9092
+    depends_on:
+      - kafka


### PR DESCRIPTION
## Summary
- add consumer Dockerfile for bank bridge service
- describe bank-bridge-consumer service in docker compose files
- update integration compose configuration
- document how to run consumer container

## Testing
- `make bankbridge-tests`

------
https://chatgpt.com/codex/tasks/task_e_6871ac542d04832d89904ef35c55af5a