### PR TITLE
Document bank-bridge consumer

### DIFF
--- a/tests/bank_bridge/test_integration_full.py
+++ b/tests/bank_bridge/test_integration_full.py
@@ -1,3 +1,10 @@
+"""Integration tests for Bank Bridge.
+
+The tests spin up Kafka and mock services using Docker Compose. To run them
+manually start ``tests/bank_bridge/docker-compose.yml`` or follow the
+instructions in ``docs/bank-bridge/README.md#kafka-consumer``.
+"""
+
 import json
 import subprocess
 import socket


### PR DESCRIPTION
## Summary
- expand bank-bridge README with a docker-compose example for the Kafka consumer
- reference this documentation from integration tests

## Testing
- `make bankbridge-tests`

------
https://chatgpt.com/codex/tasks/task_e_6872384e1b04832da50d0affb7f6dfea