### PR TITLE
Fix LeakyBucket updates for env changes

### DIFF
--- a/services/bank_bridge/limits.py
+++ b/services/bank_bridge/limits.py
@@ -82,6 +82,15 @@ def get_bucket(
     if bucket is None:
         bucket = LeakyBucket(rate=rate, capacity=capacity)
         _BUCKETS[key] = bucket
+    else:
+        # Bucket for this ``user_id``/``bank`` already exists. Environment
+        # variables may have changed between calls, so update rate and
+        # capacity to ensure new settings take effect.  Tokens are capped by
+        # the new capacity to avoid unlimited bursts.
+        if bucket.rate != rate or bucket.capacity != capacity:
+            bucket.rate = rate
+            bucket.capacity = capacity
+            bucket._tokens = min(bucket._tokens, float(capacity))
     return bucket
 
 


### PR DESCRIPTION
## Summary
- update `get_bucket` to refresh rate and capacity if environment changes

## Testing
- `pytest tests/bank_bridge/test_tinkoff_connector.py::test_connector_uses_default_limits -vv`
- ❌ `pytest --cov=backend --cov-fail-under=90 tests` *(failed to complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6872bd14991c832dac1c241a46611d54