### PR TITLE
Fix TLS test configuration

### DIFF
--- a/services/bank_bridge/__main__.py
+++ b/services/bank_bridge/__main__.py
@@ -12,12 +12,17 @@ if __name__ == "__main__":
     host = os.getenv("BANK_BRIDGE_HOST", "0.0.0.0")
     port = int(os.getenv("BANK_BRIDGE_PORT", "8080"))
 
-    config = uvicorn.Config(app, host=host, port=port)
     if certfile and keyfile and cafile:
-        ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-        ctx.load_cert_chain(certfile, keyfile)
-        ctx.load_verify_locations(cafile)
-        ctx.verify_mode = ssl.CERT_REQUIRED
-        config.ssl = ctx
+        config = uvicorn.Config(
+            app,
+            host=host,
+            port=port,
+            ssl_keyfile=keyfile,
+            ssl_certfile=certfile,
+            ssl_ca_certs=cafile,
+            ssl_cert_reqs=ssl.CERT_REQUIRED,
+        )
+    else:
+        config = uvicorn.Config(app, host=host, port=port)
     server = uvicorn.Server(config)
     server.run()

--- a/tests/bank_bridge/test_tls.py
+++ b/tests/bank_bridge/test_tls.py
@@ -15,13 +15,15 @@ async def test_client_cert_required(tmp_path):
     keyfile = cert_dir / "server.key"
     cafile = cert_dir / "ca.crt"
 
-    ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-    ctx.load_cert_chain(certfile, keyfile=str(keyfile))
-    ctx.load_verify_locations(cafile)
-    ctx.verify_mode = ssl.CERT_REQUIRED
-
-    config = Config(app=app, host="127.0.0.1", port=0)
-    config.ssl = ctx
+    config = Config(
+        app=app,
+        host="127.0.0.1",
+        port=0,
+        ssl_keyfile=str(keyfile),
+        ssl_certfile=str(certfile),
+        ssl_ca_certs=str(cafile),
+        ssl_cert_reqs=ssl.CERT_REQUIRED,
+    )
     server = Server(config)
     task = asyncio.create_task(server.serve())
     # wait for the server to start


### PR DESCRIPTION
## Summary
- configure uvicorn to use SSL settings explicitly
- update TLS test to match new ssl configuration

## Testing
- `pytest -q tests/bank_bridge/test_tls.py::test_client_cert_required`

------
https://chatgpt.com/codex/tasks/task_e_68738f8bcf10832d81bcd4bc980a52fb