### PR TITLE
Fix TLS test host mismatch

### DIFF
--- a/tests/bank_bridge/test_tls.py
+++ b/tests/bank_bridge/test_tls.py
@@ -34,7 +34,7 @@ async def test_client_cert_required(tmp_path):
     try:
         async with httpx.AsyncClient(verify=str(cafile)) as client:
             with pytest.raises(ssl.SSLError):
-                await client.get(f"https://127.0.0.1:{port}/health")
+                await client.get(f"https://localhost:{port}/health")
     finally:
         server.should_exit = True
         await task


### PR DESCRIPTION
## Summary
- fix `test_client_cert_required` to use localhost for TLS

## Testing
- `pytest tests/bank_bridge/test_tls.py::test_client_cert_required -vv`

------
https://chatgpt.com/codex/tasks/task_e_68739dee74d0832db93c0fa55dcca96e