### PR TITLE
Add bank-bridge helm chart

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,12 +18,19 @@ terraform apply
 
 ## Развёртывание приложения с Helm
 
-В каталоге `infra/helm` находится Helm-чарт. Получив kubeconfig для кластера, установите чарт:
+В каталоге `infra/helm` находится Helm-чарт для основного приложения, а в `infra/helm/bank-bridge` — отдельный чарт сервиса Bank Bridge. Получив kubeconfig для кластера, установите основной чарт:
 
 ```bash
 helm install budget-machine ./infra/helm \
   --set env.DATABASE_URL=postgresql://user:pass@db:5432/budget \
   --set env.SECRET_KEY=change_me
+```
+
+Отдельный сервис Bank Bridge устанавливается своим чартом:
+
+```bash
+helm install bank-bridge ./infra/helm/bank-bridge \
+  --set image.tag=<sha>
 ```
 
 Чарт создаст Deployment, Service и ресурс Rollout для канареечных релизов.
@@ -34,6 +41,7 @@ helm install budget-machine ./infra/helm \
 
 - `applicationset.yaml` создаёт предварительные окружения для pull request'ов с помощью `ApplicationSet`.
 - `rollout-example.yaml` демонстрирует синхронизацию чарта с автоматизированными канареечными rollout'ами.
+- `bank-bridge.yaml` развёртывает сервис Bank Bridge и применяет стратегию Argo Rollouts.
 
 Примените их к запущенному экземпляру Argo CD:
 

--- a/infra/argocd/bank-bridge.yaml
+++ b/infra/argocd/bank-bridge.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bank-bridge
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/budget-machine
+    targetRevision: HEAD
+    path: infra/helm/bank-bridge
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: bank-bridge
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/infra/helm/bank-bridge/Chart.yaml
+++ b/infra/helm/bank-bridge/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: bank-bridge
+version: 0.1.0
+description: Helm chart for the bank-bridge service
+appVersion: "0.1.0"
+type: application

--- a/infra/helm/bank-bridge/templates/_helpers.tpl
+++ b/infra/helm/bank-bridge/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "bank-bridge.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "bank-bridge.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/infra/helm/bank-bridge/templates/deployment.yaml
+++ b/infra/helm/bank-bridge/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bank-bridge.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "bank-bridge.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "bank-bridge.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "bank-bridge.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ include "bank-bridge.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          env:
+{{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+{{- end }}
+          ports:
+            - containerPort: 8080

--- a/infra/helm/bank-bridge/templates/rollout.yaml
+++ b/infra/helm/bank-bridge/templates/rollout.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ include "bank-bridge.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "bank-bridge.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "bank-bridge.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "bank-bridge.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ include "bank-bridge.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          env:
+{{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+{{- end }}
+          ports:
+            - containerPort: 8080
+  strategy:
+    canary:
+      steps:
+        - setWeight: 10
+        - pause: { duration: 30 }
+        - setWeight: 100

--- a/infra/helm/bank-bridge/templates/service.yaml
+++ b/infra/helm/bank-bridge/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bank-bridge.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "bank-bridge.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "bank-bridge.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/infra/helm/bank-bridge/values.yaml
+++ b/infra/helm/bank-bridge/values.yaml
@@ -1,0 +1,16 @@
+replicaCount: 1
+image:
+  repository: bankbridge
+  tag: "latest"
+  pullPolicy: IfNotPresent
+resources:
+  limits:
+    cpu: "1"
+    memory: 512Mi
+  requests:
+    cpu: "1"
+    memory: 512Mi
+service:
+  type: ClusterIP
+  port: 80
+env: {}


### PR DESCRIPTION
## Summary
- add Helm chart for `bank-bridge` with rollout strategy
- add Argo CD Application manifest for the new chart
- document new manifests and installation commands

## Testing
- `make ci` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68740ef88178832d80b5b32bf8177f5f