### PR TITLE
Fix posting join

### DIFF
--- a/backend/app/services/ledger.py
+++ b/backend/app/services/ledger.py
@@ -56,6 +56,7 @@ async def post_entry(
                     currency_code=item.currency_code,
                     account_id=item.account_id,
                     transaction_id=tx_obj.id,
+                    transaction_posted_at=tx_obj.posted_at,
                 )
             )
     await db.commit()


### PR DESCRIPTION
## Summary
- ensure `transaction_posted_at` of posting equals transaction's date

## Testing
- `pytest tests/api/test_categories.py::test_delete_category_in_use tests/api/test_transactions.py::test_export_transactions tests/api/test_transactions.py::test_transactions_limit tests/api/test_transactions.py::test_transactions_filter_by_account tests/grpc/test_ledger_grpc.py::test_grpc_post_entry tests/unit/test_services_ledger.py::test_post_entry_and_balance -q`

------
https://chatgpt.com/codex/tasks/task_e_6889dabad924832d8f28695c76f52f2d